### PR TITLE
GCC portability fixes

### DIFF
--- a/cython/_caramel.pxd
+++ b/cython/_caramel.pxd
@@ -1,6 +1,7 @@
 # distutils: language = c++
 
 from libc.stddef cimport size_t
+from libc.stdint cimport uint32_t, uint64_t
 from libcpp cimport bool as cbool
 from libcpp.memory cimport shared_ptr
 from libcpp.string cimport string
@@ -91,7 +92,7 @@ cdef extern from "src/construct/filter/PreFilter.h" namespace "caramel":
 
     cppclass PreFilter_uint64 "caramel::PreFilter<uint64_t>":
         cbool contains(const string &key)
-        optional[unsigned long long] getMostCommonValue()
+        optional[uint64_t] getMostCommonValue()
         optional[FilterStats] getStats()
 
     cppclass PreFilter_Char10 "caramel::PreFilter<Char10>":
@@ -233,8 +234,8 @@ cdef extern from "src/construct/Csf.h" namespace "caramel":
         shared_ptr[Csf_uint32] load(const string &filename, unsigned int type_id) except +
 
     cppclass Csf_uint64 "caramel::Csf<uint64_t>":
-        unsigned long long query(const char *data, size_t length) except +
-        unsigned long long query(const string &key) except +
+        uint64_t query(const char *data, size_t length) except +
+        uint64_t query(const string &key) except +
         shared_ptr[PreFilter_uint64] getFilter()
         CsfStats getStats()
         void save(const string &filename, unsigned int type_id) except +
@@ -280,7 +281,7 @@ cdef extern from "src/construct/Construct.h" namespace "caramel":
         shared_ptr[PreFilterConfig] filter_config, cbool verbose) except +
 
     shared_ptr[Csf_uint64] constructCsf_uint64 "caramel::constructCsf<uint64_t>"(
-        const vector[string] &keys, const vector[unsigned long long] &values,
+        const vector[string] &keys, const vector[uint64_t] &values,
         shared_ptr[PreFilterConfig] filter_config, cbool verbose) except +
 
     shared_ptr[Csf_Char10] constructCsf_Char10 "caramel::constructCsf<Char10>"(
@@ -307,8 +308,8 @@ cdef extern from "src/construct/multiset/MultisetCsf.h" namespace "caramel":
         shared_ptr[MultisetCsf_uint32] load(const string &filename, unsigned int type_id) except +
 
     cppclass MultisetCsf_uint64 "caramel::MultisetCsf<uint64_t>":
-        vector[unsigned long long] query(const char *data, size_t length, cbool parallelize) except +
-        vector[unsigned long long] query(const string &key, cbool parallelize) except +
+        vector[uint64_t] query(const char *data, size_t length, cbool parallelize) except +
+        vector[uint64_t] query(const string &key, cbool parallelize) except +
         void save(const string &filename, unsigned int type_id) except +
 
         @staticmethod
@@ -369,7 +370,7 @@ cdef extern from "src/construct/multiset/ConstructMultiset.h" namespace "caramel
         const MultisetConfig &config) except +
 
     shared_ptr[MultisetCsf_uint64] constructMultisetCsfConfig_uint64 "caramel::constructMultisetCsf<uint64_t>"(
-        const vector[string] &keys, const vector[vector[unsigned long long]] &values,
+        const vector[string] &keys, const vector[vector[uint64_t]] &values,
         const MultisetConfig &config) except +
 
     shared_ptr[MultisetCsf_Char10] constructMultisetCsfConfig_Char10 "caramel::constructMultisetCsf<Char10>"(
@@ -432,12 +433,12 @@ cdef extern from "src/baselines/UnorderedMapBaseline.h" namespace "caramel":
 
 cdef extern from "src/construct/multiset/permute/EntropyPermutation.h" namespace "caramel":
     void entropyPermutation_uint32 "caramel::entropyPermutation<uint32_t>"(unsigned int *M, int num_rows, int num_cols) nogil
-    void entropyPermutation_uint64 "caramel::entropyPermutation<uint64_t>"(unsigned long long *M, int num_rows, int num_cols) nogil
+    void entropyPermutation_uint64 "caramel::entropyPermutation<uint64_t>"(uint64_t *M, int num_rows, int num_cols) nogil
     void entropyPermutation_Char10 "caramel::entropyPermutation<Char10>"(Char10 *M, int num_rows, int num_cols) nogil
     void entropyPermutation_Char12 "caramel::entropyPermutation<Char12>"(Char12 *M, int num_rows, int num_cols) nogil
 
 cdef extern from "src/construct/multiset/permute/GlobalSortPermutation.h" namespace "caramel":
     void globalSortPermutation_uint32 "caramel::globalSortPermutation<uint32_t>"(unsigned int *M, int num_rows, int num_cols, int refinement_iterations) nogil
-    void globalSortPermutation_uint64 "caramel::globalSortPermutation<uint64_t>"(unsigned long long *M, int num_rows, int num_cols, int refinement_iterations) nogil
+    void globalSortPermutation_uint64 "caramel::globalSortPermutation<uint64_t>"(uint64_t *M, int num_rows, int num_cols, int refinement_iterations) nogil
     void globalSortPermutation_Char10 "caramel::globalSortPermutation<Char10>"(Char10 *M, int num_rows, int num_cols, int refinement_iterations) nogil
     void globalSortPermutation_Char12 "caramel::globalSortPermutation<Char12>"(Char12 *M, int num_rows, int num_cols, int refinement_iterations) nogil

--- a/cython/_caramel.pyx
+++ b/cython/_caramel.pyx
@@ -4,6 +4,7 @@
 
 from cpython.bytes cimport PyBytes_AS_STRING, PyBytes_Check, PyBytes_GET_SIZE
 from cpython.unicode cimport PyUnicode_Check, PyUnicode_DecodeUTF8
+from libc.stdint cimport uint32_t, uint64_t
 from libc.string cimport memcpy
 from libcpp cimport bool as cbool
 from libcpp.memory cimport make_shared, shared_ptr
@@ -328,7 +329,7 @@ cdef class PreFilterUint64:
         return self._ptr.get().contains(_to_cpp_string(key))
 
     def get_most_common_value(self):
-        cdef cpp.optional[unsigned long long] val = self._ptr.get().getMostCommonValue()
+        cdef cpp.optional[uint64_t] val = self._ptr.get().getMostCommonValue()
         if val.has_value():
             return val.value()
         return None
@@ -790,18 +791,18 @@ cdef class CSFUint64:
 
     def __init__(self, list keys, values, prefilter=None, bint verbose=True):
         cdef vector[string] cpp_keys = _to_cpp_strings(keys)
-        cdef vector[unsigned long long] cpp_values
+        cdef vector[uint64_t] cpp_values
         cdef shared_ptr[cpp.PreFilterConfig] filter_config
         cdef Py_ssize_t n = len(values)
 
         if isinstance(values, np.ndarray):
             arr_u64 = np.ascontiguousarray(values, dtype=np.uint64)
             cpp_values.resize(n)
-            memcpy(cpp_values.data(), (<np.ndarray>arr_u64).data, n * sizeof(unsigned long long))
+            memcpy(cpp_values.data(), (<np.ndarray>arr_u64).data, n * sizeof(uint64_t))
         else:
             cpp_values.reserve(n)
             for v in values:
-                cpp_values.push_back(<unsigned long long>v)
+                cpp_values.push_back(<uint64_t>v)
 
         if prefilter is not None and isinstance(prefilter, PreFilterConfig):
             filter_config = (<PreFilterConfig>prefilter)._ptr
@@ -817,7 +818,7 @@ cdef class CSFUint64:
     def query_batch(self, list keys):
         cdef Py_ssize_t n = len(keys)
         cdef np.ndarray[np.uint64_t, ndim=1] results = np.empty(n, dtype=np.uint64)
-        cdef unsigned long long* out = <unsigned long long*>results.data
+        cdef uint64_t* out = <uint64_t*>results.data
         cdef const char* buf
         cdef Py_ssize_t length
         for i in range(n):
@@ -1443,10 +1444,10 @@ def permute_uint64(np.ndarray[np.uint64_t, ndim=2] array not None, config=None):
     cdef int num_rows = array.shape[0]
     cdef int num_cols = array.shape[1]
     if isinstance(config, GlobalSortPermutationConfig):
-        cpp.globalSortPermutation_uint64(<unsigned long long*>array.data, num_rows, num_cols,
+        cpp.globalSortPermutation_uint64(<uint64_t*>array.data, num_rows, num_cols,
                                          (<GlobalSortPermutationConfig>config)._refinement_iterations)
     else:
-        cpp.entropyPermutation_uint64(<unsigned long long*>array.data, num_rows, num_cols)
+        cpp.entropyPermutation_uint64(<uint64_t*>array.data, num_rows, num_cols)
 
 def permute_char10(np.ndarray array not None, config=None):
     if array.ndim != 2:

--- a/cython/setup.py
+++ b/cython/setup.py
@@ -80,7 +80,7 @@ def get_compile_args():
                 args += ["-Xpreprocessor", "-fopenmp", f"-I{prefix}/include"]
                 break
     else:
-        args += ["-fopenmp"]
+        args += ["-fopenmp", "-fpermissive"]
 
     return args
 

--- a/src/construct/BucketedHashStore.h
+++ b/src/construct/BucketedHashStore.h
@@ -2,11 +2,24 @@
 
 #include "SpookyHash.h"
 #include <algorithm>
+#include <functional>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <vector>
+
+#if defined(__GNUC__) && !defined(__clang__)
+namespace std {
+template <> struct hash<__uint128_t> {
+  size_t operator()(__uint128_t v) const noexcept {
+    auto lo = static_cast<uint64_t>(v);
+    auto hi = static_cast<uint64_t>(v >> 64);
+    return hash<uint64_t>{}(lo) ^ (hash<uint64_t>{}(hi) * 0x9e3779b97f4a7c15ULL + 0x9e3779b9 + (lo << 6) + (lo >> 2));
+  }
+};
+} // namespace std
+#endif
 
 namespace caramel {
 


### PR DESCRIPTION
The Cython bindings fail to compile on GCC/libstdc++. `std::hash<__uint128_t>` is not provided by libstdc++, and a few implicit conversions involving templated `unsigned long long` vs `uint64_t` typedefs are rejected without `-fpermissive`. The project already builds on clang/libc++, so this is a toolchain-compatibility gap.