### PR TITLE
int64_t row offsets in GlobalSortPermutation

### DIFF
--- a/src/construct/multiset/ConstructRaggedMultiset.h
+++ b/src/construct/multiset/ConstructRaggedMultiset.h
@@ -52,11 +52,11 @@ constructRaggedMultisetCsf(const std::vector<std::string> &keys,
       int iters = cfg->refinement_iterations;
 
       // Build CSR-style flat buffer from ragged row-major data
-      std::vector<int> row_offsets(num_keys + 1, 0);
+      std::vector<int64_t> row_offsets(num_keys + 1, 0);
       for (size_t i = 0; i < num_keys; i++) {
         row_offsets[i + 1] = row_offsets[i] + lengths[i];
       }
-      int total = row_offsets[num_keys];
+      int64_t total = row_offsets[num_keys];
       std::vector<T> buf(total);
 
       // Column-major (col_values) → row-major flat buffer

--- a/src/construct/multiset/permute/GlobalSortPermutation.h
+++ b/src/construct/multiset/permute/GlobalSortPermutation.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <queue>
 #include <unordered_map>
 #include <vector>
@@ -13,13 +14,13 @@ namespace caramel {
 // M[row_offsets[i] .. row_offsets[i+1]).
 // `max_cols` is the maximum row length (number of column buckets for scoring).
 template <typename T>
-void globalSortPermutationRagged(T *M, const int *row_offsets, int num_rows,
+void globalSortPermutationRagged(T *M, const int64_t *row_offsets, int num_rows,
                                  int max_cols,
                                  int refinement_iterations = 5) {
   // Phase 1: Global Frequency Sort
-  int total = row_offsets[num_rows];
+  int64_t total = row_offsets[num_rows];
   std::unordered_map<T, int> global_counts;
-  for (int i = 0; i < total; i++) {
+  for (int64_t i = 0; i < total; i++) {
     global_counts[M[i]]++;
   }
 
@@ -130,9 +131,9 @@ void globalSortPermutationRagged(T *M, const int *row_offsets, int num_rows,
 template <typename T>
 void globalSortPermutation(T *M, int num_rows, int num_cols,
                            int refinement_iterations = 5) {
-  std::vector<int> row_offsets(num_rows + 1);
+  std::vector<int64_t> row_offsets(num_rows + 1);
   for (int i = 0; i <= num_rows; i++) {
-    row_offsets[i] = i * num_cols;
+    row_offsets[i] = static_cast<int64_t>(i) * num_cols;
   }
   globalSortPermutationRagged<T>(M, row_offsets.data(), num_rows, num_cols,
                                  refinement_iterations);


### PR DESCRIPTION
GlobalSortPermutation stores row offsets as `int` (and uses `int` for the total-elements counter). For inputs with N × M > 2^31 (reachable at N=100M with M≥22), the offsets overflow, thread loops read from negative offsets, and the process segfaults during construction.