### PR TITLE
Optional Huffman lookup table

### DIFF
--- a/cython/_caramel.pxd
+++ b/cython/_caramel.pxd
@@ -305,7 +305,7 @@ cdef extern from "src/construct/multiset/MultisetCsf.h" namespace "caramel":
         void save(const string &filename, unsigned int type_id) except +
 
         @staticmethod
-        shared_ptr[MultisetCsf_uint32] load(const string &filename, unsigned int type_id) except +
+        shared_ptr[MultisetCsf_uint32] load(const string &filename, unsigned int type_id, cbool build_lookup_table) except +
 
     cppclass MultisetCsf_uint64 "caramel::MultisetCsf<uint64_t>":
         vector[uint64_t] query(const char *data, size_t length, cbool parallelize) except +
@@ -313,7 +313,7 @@ cdef extern from "src/construct/multiset/MultisetCsf.h" namespace "caramel":
         void save(const string &filename, unsigned int type_id) except +
 
         @staticmethod
-        shared_ptr[MultisetCsf_uint64] load(const string &filename, unsigned int type_id) except +
+        shared_ptr[MultisetCsf_uint64] load(const string &filename, unsigned int type_id, cbool build_lookup_table) except +
 
     cppclass MultisetCsf_Char10 "caramel::MultisetCsf<Char10>":
         vector[Char10] query(const char *data, size_t length, cbool parallelize) except +
@@ -361,6 +361,7 @@ cdef extern from "src/construct/multiset/MultisetConfig.h" namespace "caramel":
         cbool shared_codebook
         cbool shared_filter
         cbool verbose
+        cbool build_lookup_table
 
 # ── ConstructMultiset free functions ───────────────────────────────────────
 

--- a/cython/_caramel.pyx
+++ b/cython/_caramel.pyx
@@ -1035,7 +1035,8 @@ cdef class MultisetCSFUint32:
     cdef shared_ptr[cpp.MultisetCsf_uint32] _ptr
 
     def __init__(self, list keys, values, prefilter=None, permutation=None,
-                 bint shared_codebook=False, bint shared_filter=False, bint verbose=True):
+                 bint shared_codebook=False, bint shared_filter=False,
+                 bint build_lookup_table=True, bint verbose=True):
         cdef vector[string] cpp_keys = _to_cpp_strings(keys)
         cdef vector[vector[unsigned int]] cpp_values
 
@@ -1059,6 +1060,7 @@ cdef class MultisetCSFUint32:
         config.verbose = verbose
         config.shared_codebook = shared_codebook
         config.shared_filter = shared_filter
+        config.build_lookup_table = build_lookup_table
         if prefilter is not None and isinstance(prefilter, PreFilterConfig):
             config.filter_config = (<PreFilterConfig>prefilter)._ptr
 
@@ -1074,10 +1076,10 @@ cdef class MultisetCSFUint32:
         self._ptr.get().save(filename.encode('utf-8'), 101)
 
     @staticmethod
-    def load(str filename):
+    def load(str filename, bint build_lookup_table=True):
         cdef MultisetCSFUint32 obj = MultisetCSFUint32.__new__(MultisetCSFUint32)
         try:
-            obj._ptr = cpp.MultisetCsf_uint32.load(filename.encode('utf-8'), 101)
+            obj._ptr = cpp.MultisetCsf_uint32.load(filename.encode('utf-8'), 101, build_lookup_table)
         except RuntimeError as e:
             raise CsfDeserializationException(str(e))
         return obj
@@ -1091,7 +1093,8 @@ cdef class MultisetCSFUint64:
     cdef shared_ptr[cpp.MultisetCsf_uint64] _ptr
 
     def __init__(self, list keys, values, prefilter=None, permutation=None,
-                 bint shared_codebook=False, bint shared_filter=False, bint verbose=True):
+                 bint shared_codebook=False, bint shared_filter=False,
+                 bint build_lookup_table=True, bint verbose=True):
         cdef vector[string] cpp_keys = _to_cpp_strings(keys)
         cdef vector[vector[unsigned long long]] cpp_values
 
@@ -1115,6 +1118,7 @@ cdef class MultisetCSFUint64:
         config.verbose = verbose
         config.shared_codebook = shared_codebook
         config.shared_filter = shared_filter
+        config.build_lookup_table = build_lookup_table
         if prefilter is not None and isinstance(prefilter, PreFilterConfig):
             config.filter_config = (<PreFilterConfig>prefilter)._ptr
 
@@ -1130,10 +1134,10 @@ cdef class MultisetCSFUint64:
         self._ptr.get().save(filename.encode('utf-8'), 102)
 
     @staticmethod
-    def load(str filename):
+    def load(str filename, bint build_lookup_table=True):
         cdef MultisetCSFUint64 obj = MultisetCSFUint64.__new__(MultisetCSFUint64)
         try:
-            obj._ptr = cpp.MultisetCsf_uint64.load(filename.encode('utf-8'), 102)
+            obj._ptr = cpp.MultisetCsf_uint64.load(filename.encode('utf-8'), 102, build_lookup_table)
         except RuntimeError as e:
             raise CsfDeserializationException(str(e))
         return obj
@@ -1147,7 +1151,8 @@ cdef class MultisetCSFChar10:
     cdef shared_ptr[cpp.MultisetCsf_Char10] _ptr
 
     def __init__(self, list keys, values, prefilter=None, permutation=None,
-                 bint shared_codebook=False, bint shared_filter=False, bint verbose=True):
+                 bint shared_codebook=False, bint shared_filter=False,
+                 bint build_lookup_table=True, bint verbose=True):
         cdef vector[string] cpp_keys = _to_cpp_strings(keys)
         cdef vector[vector[cpp.Char10]] cpp_values
 
@@ -1170,6 +1175,7 @@ cdef class MultisetCSFChar10:
         config.verbose = verbose
         config.shared_codebook = shared_codebook
         config.shared_filter = shared_filter
+        config.build_lookup_table = build_lookup_table
         if prefilter is not None and isinstance(prefilter, PreFilterConfig):
             config.filter_config = (<PreFilterConfig>prefilter)._ptr
 
@@ -1206,7 +1212,8 @@ cdef class MultisetCSFChar12:
     cdef shared_ptr[cpp.MultisetCsf_Char12] _ptr
 
     def __init__(self, list keys, values, prefilter=None, permutation=None,
-                 bint shared_codebook=False, bint shared_filter=False, bint verbose=True):
+                 bint shared_codebook=False, bint shared_filter=False,
+                 bint build_lookup_table=True, bint verbose=True):
         cdef vector[string] cpp_keys = _to_cpp_strings(keys)
         cdef vector[vector[cpp.Char12]] cpp_values
 
@@ -1229,6 +1236,7 @@ cdef class MultisetCSFChar12:
         config.verbose = verbose
         config.shared_codebook = shared_codebook
         config.shared_filter = shared_filter
+        config.build_lookup_table = build_lookup_table
         if prefilter is not None and isinstance(prefilter, PreFilterConfig):
             config.filter_config = (<PreFilterConfig>prefilter)._ptr
 
@@ -1265,7 +1273,8 @@ cdef class MultisetCSFString:
     cdef shared_ptr[cpp.MultisetCsf_string] _ptr
 
     def __init__(self, list keys, values, prefilter=None, permutation=None,
-                 bint shared_codebook=False, bint shared_filter=False, bint verbose=True):
+                 bint shared_codebook=False, bint shared_filter=False,
+                 bint build_lookup_table=True, bint verbose=True):
         cdef vector[string] cpp_keys = _to_cpp_strings(keys)
         cdef vector[vector[string]] cpp_values
 
@@ -1292,6 +1301,7 @@ cdef class MultisetCSFString:
         config.verbose = verbose
         config.shared_codebook = shared_codebook
         config.shared_filter = shared_filter
+        config.build_lookup_table = build_lookup_table
         if prefilter is not None and isinstance(prefilter, PreFilterConfig):
             config.filter_config = (<PreFilterConfig>prefilter)._ptr
 
@@ -1327,7 +1337,8 @@ cdef class RaggedMultisetCSFUint32:
     cdef shared_ptr[cpp.RaggedMultisetCsf_uint32] _ptr
 
     def __init__(self, list keys, values, prefilter=None, permutation=None,
-                 bint shared_codebook=False, bint verbose=True):
+                 bint shared_codebook=False, bint build_lookup_table=True,
+                 bint verbose=True):
         cdef vector[string] cpp_keys = _to_cpp_strings(keys)
         cdef vector[vector[unsigned int]] cpp_values
 
@@ -1339,6 +1350,7 @@ cdef class RaggedMultisetCSFUint32:
             config.permutation_config = (<PermutationConfig>permutation)._ptr
         config.verbose = verbose
         config.shared_codebook = shared_codebook
+        config.build_lookup_table = build_lookup_table
         if prefilter is not None and isinstance(prefilter, PreFilterConfig):
             config.filter_config = (<PreFilterConfig>prefilter)._ptr
 

--- a/cython/carameldb/__init__.py
+++ b/cython/carameldb/__init__.py
@@ -78,6 +78,7 @@ def Caramel(
     permutation=None,
     shared_codebook=False,
     shared_filter=False,
+    build_lookup_table=True,
     strategy=None,
     max_to_infer=None,
     verbose=True,
@@ -147,6 +148,7 @@ def Caramel(
             prefilter=prefilter,
             permutation=permutation,
             shared_codebook=shared_codebook,
+            build_lookup_table=build_lookup_table,
             verbose=verbose,
         )
 
@@ -167,6 +169,7 @@ def Caramel(
             permutation=permutation,
             shared_codebook=shared_codebook,
             shared_filter=shared_filter,
+            build_lookup_table=build_lookup_table,
             verbose=verbose,
         )
     else:

--- a/src/construct/Csf.h
+++ b/src/construct/Csf.h
@@ -189,7 +189,8 @@ private:
     }
 
     return queryCsfCore<T>(data, length, _hash_store_seed, _bucket_info,
-                           _num_buckets, _max_codelength, _lookup_table);
+                           _num_buckets, _max_codelength, _lookup_table,
+                           _code_length_counts, _ordered_symbols);
   }
 
   // Private constructor for cereal

--- a/src/construct/CsfCodebook.h
+++ b/src/construct/CsfCodebook.h
@@ -194,12 +194,8 @@ private:
 };
 
 template <typename T>
-CsfCodebook<T> canonicalHuffman(const std::vector<T> &symbols) {
-  std::unordered_map<T, uint64_t> frequencies;
-  for (const auto &symbol : symbols) {
-    ++frequencies[symbol];
-  }
-
+CsfCodebook<T>
+canonicalHuffmanFromFrequencies(const std::unordered_map<T, uint64_t> &frequencies) {
   // TODO(david) unwrap this into a two separate vectors since we end up copying
   std::vector<std::pair<T, uint64_t>> symbol_frequency_pairs(
       frequencies.begin(), frequencies.end());
@@ -250,6 +246,15 @@ CsfCodebook<T> canonicalHuffman(const std::vector<T> &symbols) {
   cb.codedict = std::move(codedict);
   cb.buildLookupTable();
   return cb;
+}
+
+template <typename T>
+CsfCodebook<T> canonicalHuffman(const std::vector<T> &symbols) {
+  std::unordered_map<T, uint64_t> frequencies;
+  for (const auto &symbol : symbols) {
+    ++frequencies[symbol];
+  }
+  return canonicalHuffmanFromFrequencies<T>(frequencies);
 }
 
 } // namespace caramel

--- a/src/construct/CsfCodebook.h
+++ b/src/construct/CsfCodebook.h
@@ -189,7 +189,6 @@ private:
 
   template <class Archive> void load(Archive &archive) {
     archive(code_length_counts, ordered_symbols, max_codelength);
-    buildLookupTable();
   }
 };
 
@@ -244,7 +243,6 @@ canonicalHuffmanFromFrequencies(const std::unordered_map<T, uint64_t> &frequenci
   cb.ordered_symbols = std::move(ordered_symbols);
   cb.max_codelength = cb.code_length_counts.size() - 1;
   cb.codedict = std::move(codedict);
-  cb.buildLookupTable();
   return cb;
 }
 

--- a/src/construct/CsfQueryCore.h
+++ b/src/construct/CsfQueryCore.h
@@ -17,7 +17,9 @@ template <typename T>
 T queryCsfCore(const char *data, size_t length, uint32_t hash_store_seed,
                const std::vector<BucketQueryInfo> &bucket_info,
                uint32_t num_buckets, uint32_t max_codelength,
-               const HuffmanLookupTable<T> &lookup_table) {
+               const HuffmanLookupTable<T> &lookup_table,
+               const std::vector<uint32_t> &code_length_counts,
+               const std::vector<T> &ordered_symbols) {
   __uint128_t signature = hashKey(data, length, hash_store_seed);
 
   uint32_t bucket_id = getBucketID(signature, num_buckets);
@@ -39,6 +41,10 @@ T queryCsfCore(const char *data, size_t length, uint32_t hash_store_seed,
 
   uint64_t encoded_value = getbits(e[0]) ^ getbits(e[1]) ^ getbits(e[2]);
 
+  if (lookup_table.symbols_by_code.empty()) {
+    return canonicalDecodeFromNumber<T>(encoded_value, code_length_counts,
+                                        ordered_symbols, max_codelength);
+  }
   return lookup_table.decode(encoded_value);
 }
 

--- a/src/construct/multiset/ConstructMultiset.h
+++ b/src/construct/multiset/ConstructMultiset.h
@@ -268,6 +268,9 @@ constructMultisetCsf(const std::vector<std::string> &keys,
     columns[i].filter = col_inputs.filter;
     columns[i].most_common_value = col_inputs.most_common_value;
     columns[i].buildQueryCache();
+    if (config.build_lookup_table && columns[i].codebook) {
+      columns[i].codebook->buildLookupTable();
+    }
   }
 
   return std::make_shared<MultisetCsf<T>>(std::move(columns));

--- a/src/construct/multiset/ConstructRaggedMultiset.h
+++ b/src/construct/multiset/ConstructRaggedMultiset.h
@@ -187,6 +187,9 @@ constructRaggedMultisetCsf(const std::vector<std::string> &keys,
     columns[c].filter = col_filter;
     columns[c].most_common_value = mcv;
     columns[c].buildQueryCache();
+    if (config.build_lookup_table && columns[c].codebook) {
+      columns[c].codebook->buildLookupTable();
+    }
   }
 
   return std::make_shared<RaggedMultisetCsf<T>>(std::move(length_csf),

--- a/src/construct/multiset/MultisetConfig.h
+++ b/src/construct/multiset/MultisetConfig.h
@@ -11,6 +11,10 @@ struct MultisetConfig {
   bool shared_codebook = false;
   bool shared_filter = false;
   bool verbose = true;
+  // If false, skip building Huffman lookup tables at reload time.
+  // Queries fall back to O(max_codelength) canonical decode.
+  // Saves ~2^max_codelength * sizeof(T) bytes per column.
+  bool build_lookup_table = true;
 };
 
 } // namespace caramel

--- a/src/construct/multiset/MultisetCsf.h
+++ b/src/construct/multiset/MultisetCsf.h
@@ -72,7 +72,9 @@ public:
         outputs[i] = queryCsfCore<T>(data, length, col.hash_store_seed,
                                      col.bucket_info, col.num_buckets,
                                      col.codebook->max_codelength,
-                                     col.codebook->lookup_table);
+                                     col.codebook->lookup_table,
+                                     col.codebook->code_length_counts,
+                                     col.codebook->ordered_symbols);
       }
     }
 
@@ -88,7 +90,8 @@ public:
   }
 
   static MultisetCsfPtr<T> load(const std::string &filename,
-                                const uint32_t type_id = 0) {
+                                const uint32_t type_id = 0,
+                                bool build_lookup_table = true) {
     auto input_stream = SafeFileIO::ifstream(filename, std::ios::binary);
     uint32_t type_id_found = 0;
     input_stream.read(reinterpret_cast<char *>(&type_id_found),
@@ -102,6 +105,13 @@ public:
     cereal::BinaryInputArchive iarchive(input_stream);
     MultisetCsfPtr<T> deserialize_into(new MultisetCsf<T>());
     iarchive(*deserialize_into);
+    if (build_lookup_table) {
+      for (auto &col : deserialize_into->_columns) {
+        if (col.codebook) {
+          col.codebook->buildLookupTable();
+        }
+      }
+    }
     return deserialize_into;
   }
 

--- a/src/construct/multiset/RaggedMultisetCsf.h
+++ b/src/construct/multiset/RaggedMultisetCsf.h
@@ -38,7 +38,9 @@ public:
         outputs[i] = queryCsfCore<T>(data, length, col.hash_store_seed,
                                      col.bucket_info, col.num_buckets,
                                      col.codebook->max_codelength,
-                                     col.codebook->lookup_table);
+                                     col.codebook->lookup_table,
+                                     col.codebook->code_length_counts,
+                                     col.codebook->ordered_symbols);
       }
     }
 
@@ -54,7 +56,8 @@ public:
   }
 
   static RaggedMultisetCsfPtr<T> load(const std::string &filename,
-                                      const uint32_t type_id = 0) {
+                                      const uint32_t type_id = 0,
+                                      bool build_lookup_table = true) {
     auto input_stream = SafeFileIO::ifstream(filename, std::ios::binary);
     uint32_t type_id_found = 0;
     input_stream.read(reinterpret_cast<char *>(&type_id_found),
@@ -68,6 +71,13 @@ public:
     cereal::BinaryInputArchive iarchive(input_stream);
     RaggedMultisetCsfPtr<T> deserialize_into(new RaggedMultisetCsf<T>());
     iarchive(*deserialize_into);
+    if (build_lookup_table) {
+      for (auto &col : deserialize_into->_columns) {
+        if (col.codebook) {
+          col.codebook->buildLookupTable();
+        }
+      }
+    }
     return deserialize_into;
   }
 


### PR DESCRIPTION
Each per-column Huffman lookup table consumes 2^max_codelength × sizeof(T) bytes of RSS — multiple GB for a wide MultisetCSF (M=100 columns, uint64 values). Callers that can tolerate slower queries (or are purely measuring construction size) have no way to skip the LUT, and there is no fallback decode path in `queryCsfCore` if the LUT is missing.