### PR TITLE
Row-major MultisetCSF construction

### DIFF
--- a/cython/_caramel.pxd
+++ b/cython/_caramel.pxd
@@ -385,6 +385,28 @@ cdef extern from "src/construct/multiset/ConstructMultiset.h" namespace "caramel
         const vector[string] &keys, const vector[vector[string]] &values,
         const MultisetConfig &config) except +
 
+
+# ── Row-major construction (avoids column copy) ──────────────────────────
+
+cdef extern from "src/construct/multiset/ConstructMultiset.h" namespace "caramel":
+    cppclass MultisetConstructionResult_uint32 "caramel::MultisetConstructionResult<uint32_t>":
+        shared_ptr[MultisetCsf_uint32] csf
+        double permutation_seconds
+        double build_seconds
+
+    cppclass MultisetConstructionResult_uint64 "caramel::MultisetConstructionResult<uint64_t>":
+        shared_ptr[MultisetCsf_uint64] csf
+        double permutation_seconds
+        double build_seconds
+
+    MultisetConstructionResult_uint32 constructMultisetCsfRowMajor_uint32 "caramel::constructMultisetCsfRowMajor<uint32_t>"(
+        const vector[string] &keys, unsigned int *data, int num_rows, int num_cols,
+        const MultisetConfig &config) except +
+
+    MultisetConstructionResult_uint64 constructMultisetCsfRowMajor_uint64 "caramel::constructMultisetCsfRowMajor<uint64_t>"(
+        const vector[string] &keys, uint64_t *data, int num_rows, int num_cols,
+        const MultisetConfig &config) except +
+
 # ── RaggedMultisetCsf ─────────────────────────────────────────────────────
 
 cdef extern from "src/construct/multiset/RaggedMultisetCsf.h" namespace "caramel":

--- a/cython/_caramel.pyx
+++ b/cython/_caramel.pyx
@@ -1043,15 +1043,19 @@ cdef class CSFString:
 
 cdef class MultisetCSFUint32:
     cdef shared_ptr[cpp.MultisetCsf_uint32] _ptr
+    cdef public double permutation_seconds
+    cdef public double build_seconds
 
     def __init__(self, keys, values, prefilter=None, permutation=None,
                  bint shared_codebook=False, bint shared_filter=False, bint verbose=True):
+        """
+        Note: when `permutation` is set, `values` is mutated in place.
+        """
         cdef vector[string] cpp_keys
         if isinstance(keys, np.ndarray) and (<np.ndarray>keys).dtype == np.uint32:
             cpp_keys = _uint32_array_to_cpp_strings(np.ascontiguousarray(keys))
         else:
             cpp_keys = _to_cpp_strings(keys)
-        cdef vector[vector[unsigned int]] cpp_values
 
         values = np.ascontiguousarray(values, dtype=np.uint32)
         if values.ndim != 2:
@@ -1059,13 +1063,6 @@ cdef class MultisetCSFUint32:
 
         cdef int num_rows = values.shape[0]
         cdef int num_cols = values.shape[1]
-        cdef vector[unsigned int] col_vec
-        cpp_values.reserve(num_cols)
-        for col_idx in range(num_cols):
-            arr_col = np.ascontiguousarray(values[:, col_idx])
-            col_vec.resize(num_rows)
-            memcpy(col_vec.data(), (<np.ndarray>arr_col).data, num_rows * sizeof(unsigned int))
-            cpp_values.push_back(col_vec)
 
         cdef cpp.MultisetConfig config
         if permutation is not None and isinstance(permutation, PermutationConfig):
@@ -1076,7 +1073,13 @@ cdef class MultisetCSFUint32:
         if prefilter is not None and isinstance(prefilter, PreFilterConfig):
             config.filter_config = (<PreFilterConfig>prefilter)._ptr
 
-        self._ptr = cpp.constructMultisetCsfConfig_uint32(cpp_keys, cpp_values, config)
+        cdef cpp.MultisetConstructionResult_uint32 result
+        result = cpp.constructMultisetCsfRowMajor_uint32(
+            cpp_keys, <unsigned int*>(<np.ndarray>values).data,
+            num_rows, num_cols, config)
+        self._ptr = result.csf
+        self.permutation_seconds = result.permutation_seconds
+        self.build_seconds = result.build_seconds
 
     def query(self, key, bint parallel=False):
         cdef unsigned int uint_key
@@ -1098,6 +1101,8 @@ cdef class MultisetCSFUint32:
             obj._ptr = cpp.MultisetCsf_uint32.load(filename.encode('utf-8'), 101)
         except RuntimeError as e:
             raise CsfDeserializationException(str(e))
+        obj.permutation_seconds = 0.0
+        obj.build_seconds = 0.0
         return obj
 
     @staticmethod
@@ -1107,15 +1112,19 @@ cdef class MultisetCSFUint32:
 
 cdef class MultisetCSFUint64:
     cdef shared_ptr[cpp.MultisetCsf_uint64] _ptr
+    cdef public double permutation_seconds
+    cdef public double build_seconds
 
     def __init__(self, keys, values, prefilter=None, permutation=None,
                  bint shared_codebook=False, bint shared_filter=False, bint verbose=True):
+        """
+        Note: when `permutation` is set, `values` is mutated in place.
+        """
         cdef vector[string] cpp_keys
         if isinstance(keys, np.ndarray) and (<np.ndarray>keys).dtype == np.uint32:
             cpp_keys = _uint32_array_to_cpp_strings(np.ascontiguousarray(keys))
         else:
             cpp_keys = _to_cpp_strings(keys)
-        cdef vector[vector[uint64_t]] cpp_values
 
         values = np.ascontiguousarray(values, dtype=np.uint64)
         if values.ndim != 2:
@@ -1123,13 +1132,6 @@ cdef class MultisetCSFUint64:
 
         cdef int num_rows = values.shape[0]
         cdef int num_cols = values.shape[1]
-        cdef vector[uint64_t] col_vec
-        cpp_values.reserve(num_cols)
-        for col_idx in range(num_cols):
-            arr_col = np.ascontiguousarray(values[:, col_idx])
-            col_vec.resize(num_rows)
-            memcpy(col_vec.data(), (<np.ndarray>arr_col).data, num_rows * sizeof(uint64_t))
-            cpp_values.push_back(col_vec)
 
         cdef cpp.MultisetConfig config
         if permutation is not None and isinstance(permutation, PermutationConfig):
@@ -1140,7 +1142,13 @@ cdef class MultisetCSFUint64:
         if prefilter is not None and isinstance(prefilter, PreFilterConfig):
             config.filter_config = (<PreFilterConfig>prefilter)._ptr
 
-        self._ptr = cpp.constructMultisetCsfConfig_uint64(cpp_keys, cpp_values, config)
+        cdef cpp.MultisetConstructionResult_uint64 result
+        result = cpp.constructMultisetCsfRowMajor_uint64(
+            cpp_keys, <uint64_t*>(<np.ndarray>values).data,
+            num_rows, num_cols, config)
+        self._ptr = result.csf
+        self.permutation_seconds = result.permutation_seconds
+        self.build_seconds = result.build_seconds
 
     def query(self, key, bint parallel=False):
         cdef unsigned int uint_key
@@ -1162,6 +1170,8 @@ cdef class MultisetCSFUint64:
             obj._ptr = cpp.MultisetCsf_uint64.load(filename.encode('utf-8'), 102)
         except RuntimeError as e:
             raise CsfDeserializationException(str(e))
+        obj.permutation_seconds = 0.0
+        obj.build_seconds = 0.0
         return obj
 
     @staticmethod

--- a/src/construct/multiset/ConstructMultiset.h
+++ b/src/construct/multiset/ConstructMultiset.h
@@ -6,6 +6,7 @@
 #include "src/construct/multiset/MultisetCsf.h"
 #include "src/construct/multiset/MultisetConfig.h"
 #include "src/construct/filter/FilterFactory.h"
+#include "src/utils/Timer.h"
 
 namespace caramel {
 
@@ -271,6 +272,134 @@ constructMultisetCsf(const std::vector<std::string> &keys,
   }
 
   return std::make_shared<MultisetCsf<T>>(std::move(columns));
+}
+
+template <typename T>
+struct MultisetConstructionResult {
+  MultisetCsfPtr<T> csf;
+  double permutation_seconds = 0.0;
+  double build_seconds = 0.0;
+};
+
+// Constructs a MultisetCsf from a row-major flat buffer (T* data, num_rows x
+// num_cols). Avoids the memory doubling of the vector<vector<T>> overload by
+// extracting columns on-the-fly. Returns timing stats for permutation and build.
+template <typename T>
+MultisetConstructionResult<T>
+constructMultisetCsfRowMajor(const std::vector<std::string> &keys,
+                             T *data, int num_rows, int num_cols,
+                             const MultisetConfig &config) {
+  MultisetConstructionResult<T> result;
+  Timer timer;
+
+  if (config.permutation_config && num_cols > 1) {
+    if (std::dynamic_pointer_cast<EntropyPermutationConfig>(
+            config.permutation_config)) {
+      entropyPermutation<T>(data, num_rows, num_cols);
+    } else if (auto cfg =
+                   std::dynamic_pointer_cast<GlobalSortPermutationConfig>(
+                       config.permutation_config)) {
+      globalSortPermutation<T>(data, num_rows, num_cols,
+                               cfg->refinement_iterations);
+    }
+  }
+  result.permutation_seconds = timer.seconds();
+
+  size_t num_columns = static_cast<size_t>(num_cols);
+  size_t n = static_cast<size_t>(num_rows);
+
+  std::shared_ptr<CsfCodebook<T>> shared_cb;
+  if (config.shared_codebook) {
+    size_t total = n * num_columns;
+    std::unordered_map<T, uint64_t> freqs;
+    for (size_t i = 0; i < total; i++) {
+      ++freqs[data[i]];
+    }
+    shared_cb = std::make_shared<CsfCodebook<T>>(
+        canonicalHuffmanFromFrequencies<T>(freqs));
+  }
+
+  std::vector<ColumnFilterInfo<T>> group_filters;
+  if (config.shared_filter && config.filter_config) {
+    std::vector<std::vector<T>> col_values(num_columns);
+    for (size_t c = 0; c < num_columns; c++) {
+      col_values[c].resize(n);
+      for (size_t r = 0; r < n; r++) {
+        col_values[c][r] = data[r * num_columns + c];
+      }
+    }
+    group_filters = buildGroupSharedFilters<T>(keys, col_values,
+                                               config.filter_config,
+                                               config.verbose);
+  }
+
+  using ColumnState = typename MultisetCsf<T>::ColumnState;
+  std::vector<ColumnState> columns(num_columns);
+  std::vector<T> column_values(n);
+
+  for (size_t i = 0; i < num_columns; i++) {
+    for (size_t r = 0; r < n; r++) {
+      column_values[r] = data[r * num_columns + i];
+    }
+
+    auto *col_filter = group_filters.empty() ? nullptr : &group_filters[i];
+    auto col_inputs = resolveColumnInputs<T>(
+        keys, column_values, col_filter, config.filter_config, config.verbose);
+
+    bool using_filter = (col_inputs.filter != nullptr);
+    const auto &active_keys = using_filter ? col_inputs.keys : keys;
+    const auto &active_values = using_filter ? col_inputs.values : column_values;
+
+    auto col_codebook = config.shared_codebook
+        ? shared_cb
+        : std::make_shared<CsfCodebook<T>>(canonicalHuffman<T>(active_values));
+
+    const CodeDict<T> &codedict = col_codebook->codedict;
+    uint32_t max_cl = col_codebook->max_codelength;
+
+    uint64_t num_buckets = targetBucketCount(active_values, codedict);
+
+    BucketedHashStore<T> hash_store =
+        partitionToBuckets<T>(active_keys, active_values, num_buckets);
+
+    std::exception_ptr exception = nullptr;
+    std::vector<SubsystemSolutionSeedPair> solutions_and_seeds(
+        hash_store.num_buckets);
+
+#pragma omp parallel for default(none)                                         \
+    shared(hash_store, solutions_and_seeds, exception, DELTA,                  \
+           codedict, max_cl)
+    for (uint32_t j = 0; j < hash_store.num_buckets; j++) {
+      if (exception) {
+        continue;
+      }
+      try {
+        solutions_and_seeds[j] = constructAndSolveSubsystem<T>(
+            hash_store.key_buckets[j], hash_store.value_buckets[j],
+            codedict, max_cl, DELTA);
+      } catch (std::exception &e) {
+#pragma omp critical
+        {
+          exception = std::current_exception();
+        }
+      }
+    }
+
+    if (exception) {
+      std::rethrow_exception(exception);
+    }
+
+    columns[i].solutions_and_seeds = std::move(solutions_and_seeds);
+    columns[i].hash_store_seed = hash_store.seed;
+    columns[i].codebook = col_codebook;
+    columns[i].filter = col_inputs.filter;
+    columns[i].most_common_value = col_inputs.most_common_value;
+    columns[i].buildQueryCache();
+  }
+
+  result.build_seconds = timer.seconds();
+  result.csf = std::make_shared<MultisetCsf<T>>(std::move(columns));
+  return result;
 }
 
 } // namespace caramel


### PR DESCRIPTION
The MultisetCSF constructor takes `vector<vector<T>>` (column-major). When the caller has the data in a row-major numpy array, the Cython wrapper copies every cell into column vectors, doubling peak RAM during the ingest phase of construction. On a 100M × 100 uint32 dataset that duplicated allocation is 40+ GB.

Additionally, there's no way to tell how long the permutation phase vs the solve phase took — both are lumped into the single wall-clock time of the constructor.