### PR TITLE
Retroactive shared-codebook size calculator

### DIFF
--- a/cython/_caramel.pxd
+++ b/cython/_caramel.pxd
@@ -1,6 +1,7 @@
 # distutils: language = c++
 
 from libc.stddef cimport size_t
+from libc.stdint cimport uint64_t
 from libcpp cimport bool as cbool
 from libcpp.memory cimport shared_ptr
 from libcpp.string cimport string
@@ -25,6 +26,14 @@ cdef extern from "<optional>" namespace "std" nogil:
         optional(T&)
         cbool has_value()
         T& value()
+
+# ── Shared-codebook retroactive size helper ───────────────────────────────
+
+cdef extern from "src/construct/CsfCodebook.h" namespace "caramel":
+    size_t sharedCodebookSerializedBytes_uint32 "caramel::sharedCodebookSerializedBytes<uint32_t>"(
+        const unsigned int *data, size_t n, size_t m) nogil
+    size_t sharedCodebookSerializedBytes_uint64 "caramel::sharedCodebookSerializedBytes<uint64_t>"(
+        const uint64_t *data, size_t n, size_t m) nogil
 
 # ── Stats ──────────────────────────────────────────────────────────────────
 

--- a/cython/_caramel.pyx
+++ b/cython/_caramel.pyx
@@ -1481,3 +1481,46 @@ def permute_char12(np.ndarray array not None, config=None):
                                          (<GlobalSortPermutationConfig>config)._refinement_iterations)
     else:
         cpp.entropyPermutation_Char12(<cpp.Char12*>array.data, num_rows, num_cols)
+
+
+# ── Shared-codebook retroactive size calculator ───────────────────────────
+
+def shared_codebook_serialized_bytes(values not None):
+    """Compute the serialized byte size of the shared codebook that a MultisetCSF
+    with shared_codebook=True would produce over the given 2D values array.
+
+    Streams a pooled frequency histogram from the input (accepts mmap arrays;
+    does not copy), builds a canonical Huffman codebook via
+    canonicalHuffmanFromFrequencies, cereal-serializes the codebook, and
+    returns the byte count.
+
+    Parameters
+    ----------
+    values : 2D numpy array with dtype uint32 or uint64 (row-major).
+
+    Returns
+    -------
+    int : number of bytes one shared codebook consumes when cereal-serialized.
+    """
+    cdef np.ndarray arr = np.asarray(values)
+    if arr.ndim != 2:
+        raise ValueError(f"values must be 2D, got ndim={arr.ndim}")
+    if not arr.flags['C_CONTIGUOUS']:
+        arr = np.ascontiguousarray(arr)
+
+    cdef size_t n = arr.shape[0]
+    cdef size_t m = arr.shape[1]
+    cdef size_t result
+
+    if arr.dtype == np.uint32:
+        with nogil:
+            result = cpp.sharedCodebookSerializedBytes_uint32(
+                <const unsigned int*>arr.data, n, m)
+        return result
+    elif arr.dtype == np.uint64:
+        with nogil:
+            result = cpp.sharedCodebookSerializedBytes_uint64(
+                <const unsigned long long*>arr.data, n, m)
+        return result
+    else:
+        raise TypeError(f"values must be uint32 or uint64, got {arr.dtype}")

--- a/cython/carameldb/__init__.py
+++ b/cython/carameldb/__init__.py
@@ -43,6 +43,7 @@ from ._caramel import (
     permute_char12,
     permute_uint32,
     permute_uint64,
+    shared_codebook_serialized_bytes,
 )
 
 CLASS_LIST = [

--- a/python_tests/test_multiset_csf.py
+++ b/python_tests/test_multiset_csf.py
@@ -307,3 +307,40 @@ def test_backward_compat_default_settings(tmp_path):
     csf2 = carameldb.load(save_file)
     for key, row in zip(keys, values):
         assert csf2.query(key) == list(row)
+
+
+def test_shared_codebook_serialized_bytes():
+    """The retroactive helper returns positive bytes for any non-trivial input."""
+    num_rows = 1000
+    num_cols = 20
+    rng = np.random.default_rng(42)
+    values = rng.integers(1, 500, size=(num_rows, num_cols), dtype=np.uint32)
+
+    cb_bytes = carameldb.shared_codebook_serialized_bytes(values)
+    assert cb_bytes > 0
+    assert isinstance(cb_bytes, int)
+
+
+def test_shared_codebook_serialized_bytes_accepts_mmap(tmp_path):
+    """Helper must work on an mmap'd numpy array without copying."""
+    rng = np.random.default_rng(7)
+    values_src = rng.integers(0, 50, size=(500, 10), dtype=np.uint32)
+    path = tmp_path / "vals.npy"
+    np.save(path, values_src)
+
+    values_mmap = np.load(path, mmap_mode='r')
+    cb_bytes = carameldb.shared_codebook_serialized_bytes(values_mmap)
+    assert cb_bytes > 0
+
+    cb_bytes_ram = carameldb.shared_codebook_serialized_bytes(values_src)
+    assert cb_bytes == cb_bytes_ram
+
+
+def test_shared_codebook_serialized_bytes_dtype():
+    rng = np.random.default_rng(0)
+    vals32 = rng.integers(0, 100, size=(200, 5), dtype=np.uint32)
+    vals64 = vals32.astype(np.uint64)
+    b32 = carameldb.shared_codebook_serialized_bytes(vals32)
+    b64 = carameldb.shared_codebook_serialized_bytes(vals64)
+    assert b32 > 0 and b64 > 0
+    assert b64 > b32

--- a/src/construct/CsfCodebook.h
+++ b/src/construct/CsfCodebook.h
@@ -2,7 +2,9 @@
 
 #include <algorithm>
 #include <cereal/access.hpp>
+#include <cereal/archives/binary.hpp>
 #include <cereal/types/vector.hpp>
+#include <sstream>
 #include <src/BitArray.h>
 #include <stdexcept>
 #include <unordered_map>
@@ -253,6 +255,35 @@ CsfCodebook<T> canonicalHuffman(const std::vector<T> &symbols) {
     ++frequencies[symbol];
   }
   return canonicalHuffmanFromFrequencies<T>(frequencies);
+}
+
+// Serializes a codebook via cereal and returns the byte count. Used by the
+// retroactive cost calculator to measure how many bytes one shared codebook
+// consumes on disk (so we can correct buggy SharedCB saves that duplicated
+// the codebook across m columns).
+template <typename T>
+inline size_t serializedCodebookBytes(const CsfCodebook<T> &cb) {
+  std::stringstream ss;
+  {
+    cereal::BinaryOutputArchive archive(ss);
+    archive(cb);
+  }
+  return ss.str().size();
+}
+
+// Streams pooled frequencies from a row-major flat buffer (n rows x m cols),
+// builds a canonical Huffman codebook, serializes it via cereal, and returns
+// the byte count. Equivalent to what a MultisetCSF with shared_codebook=True
+// would produce, minus the CSF/bit-array construction.
+template <typename T>
+inline size_t sharedCodebookSerializedBytes(const T *data, size_t n, size_t m) {
+  std::unordered_map<T, uint32_t> freqs;
+  size_t total = n * m;
+  for (size_t i = 0; i < total; i++) {
+    ++freqs[data[i]];
+  }
+  CsfCodebook<T> cb = canonicalHuffmanFromFrequencies<T>(freqs);
+  return serializedCodebookBytes(cb);
 }
 
 } // namespace caramel


### PR DESCRIPTION
After fixing the MultisetCSF save format to store a shared codebook only once instead of duplicating it M times per column, existing benchmark results from before the fix over-report the on-disk size for shared-codebook runs. Re-running the full empirical grid to collect corrected numbers takes days per configuration, but the correction is deterministic: per-config savings equal (M - 1) × (bytes one serialized codebook takes). Callers need a way to compute that serialized-codebook byte count from the raw values without rebuilding the whole CSF.