### PR TITLE
Remove Huffman lookup table

### DIFF
--- a/src/construct/Csf.h
+++ b/src/construct/Csf.h
@@ -189,7 +189,8 @@ private:
     }
 
     return queryCsfCore<T>(data, length, _hash_store_seed, _bucket_info,
-                           _num_buckets, _max_codelength, _lookup_table);
+                           _num_buckets, _max_codelength, _code_length_counts,
+                           _ordered_symbols);
   }
 
   // Private constructor for cereal
@@ -197,10 +198,6 @@ private:
 
   void _buildQueryCache() {
     _num_buckets = _solutions_and_seeds.size();
-    if (!_code_length_counts.empty() && _max_codelength > 0) {
-      _lookup_table = HuffmanLookupTable<T>(_code_length_counts,
-                                            _ordered_symbols, _max_codelength);
-    }
     _bucket_info.resize(_num_buckets);
     for (uint32_t i = 0; i < _num_buckets; i++) {
       auto &[solution, seed] = _solutions_and_seeds[i];
@@ -233,7 +230,6 @@ private:
   // Query cache (built from _solutions_and_seeds, not serialized)
   uint32_t _num_buckets = 0;
   std::vector<BucketQueryInfo> _bucket_info;
-  HuffmanLookupTable<T> _lookup_table;
 };
 
 } // namespace caramel

--- a/src/construct/CsfCodebook.h
+++ b/src/construct/CsfCodebook.h
@@ -135,61 +135,19 @@ inline T canonicalDecodeFromNumber(
   throw std::invalid_argument("Invalid Code Passed");
 }
 
-template <typename T> struct HuffmanLookupTable {
-  std::vector<T> symbols_by_code;
-  uint32_t max_codelength;
-
-  HuffmanLookupTable() : max_codelength(0) {}
-
-  HuffmanLookupTable(const std::vector<uint32_t> &code_length_counts,
-                     const std::vector<T> &ordered_symbols,
-                     uint32_t max_cl)
-      : max_codelength(max_cl) {
-    if (max_codelength == 0 || ordered_symbols.empty())
-      return;
-    uint64_t table_size = 1ULL << max_codelength;
-    symbols_by_code.resize(table_size, ordered_symbols[0]);
-    for (uint64_t val = 0; val < table_size; val++) {
-      try {
-        symbols_by_code[val] = canonicalDecodeFromNumber(
-            val, code_length_counts, ordered_symbols, max_codelength);
-      } catch (const std::invalid_argument &) {
-        // Invalid code - leave as default. Will never be queried for valid keys.
-      }
-    }
-  }
-
-  inline T decode(uint64_t encoded_value) const {
-    return symbols_by_code[encoded_value];
-  }
-};
-
 template <typename T> struct CsfCodebook {
   std::vector<uint32_t> code_length_counts;
   std::vector<T> ordered_symbols;
   uint32_t max_codelength = 0;
-  HuffmanLookupTable<T> lookup_table;
   CodeDict<T> codedict;
 
   CsfCodebook() = default;
 
-  void buildLookupTable() {
-    if (!code_length_counts.empty() && max_codelength > 0) {
-      lookup_table = HuffmanLookupTable<T>(code_length_counts, ordered_symbols,
-                                           max_codelength);
-    }
-  }
-
 private:
   friend class cereal::access;
 
-  template <class Archive> void save(Archive &archive) const {
+  template <class Archive> void serialize(Archive &archive) {
     archive(code_length_counts, ordered_symbols, max_codelength);
-  }
-
-  template <class Archive> void load(Archive &archive) {
-    archive(code_length_counts, ordered_symbols, max_codelength);
-    buildLookupTable();
   }
 };
 
@@ -244,7 +202,6 @@ canonicalHuffmanFromFrequencies(const std::unordered_map<T, uint64_t> &frequenci
   cb.ordered_symbols = std::move(ordered_symbols);
   cb.max_codelength = cb.code_length_counts.size() - 1;
   cb.codedict = std::move(codedict);
-  cb.buildLookupTable();
   return cb;
 }
 

--- a/src/construct/CsfQueryCore.h
+++ b/src/construct/CsfQueryCore.h
@@ -17,7 +17,8 @@ template <typename T>
 T queryCsfCore(const char *data, size_t length, uint32_t hash_store_seed,
                const std::vector<BucketQueryInfo> &bucket_info,
                uint32_t num_buckets, uint32_t max_codelength,
-               const HuffmanLookupTable<T> &lookup_table) {
+               const std::vector<uint32_t> &code_length_counts,
+               const std::vector<T> &ordered_symbols) {
   __uint128_t signature = hashKey(data, length, hash_store_seed);
 
   uint32_t bucket_id = getBucketID(signature, num_buckets);
@@ -39,7 +40,8 @@ T queryCsfCore(const char *data, size_t length, uint32_t hash_store_seed,
 
   uint64_t encoded_value = getbits(e[0]) ^ getbits(e[1]) ^ getbits(e[2]);
 
-  return lookup_table.decode(encoded_value);
+  return canonicalDecodeFromNumber<T>(encoded_value, code_length_counts,
+                                      ordered_symbols, max_codelength);
 }
 
 } // namespace caramel

--- a/src/construct/multiset/MultisetCsf.h
+++ b/src/construct/multiset/MultisetCsf.h
@@ -72,7 +72,8 @@ public:
         outputs[i] = queryCsfCore<T>(data, length, col.hash_store_seed,
                                      col.bucket_info, col.num_buckets,
                                      col.codebook->max_codelength,
-                                     col.codebook->lookup_table);
+                                     col.codebook->code_length_counts,
+                                     col.codebook->ordered_symbols);
       }
     }
 

--- a/src/construct/multiset/RaggedMultisetCsf.h
+++ b/src/construct/multiset/RaggedMultisetCsf.h
@@ -38,7 +38,8 @@ public:
         outputs[i] = queryCsfCore<T>(data, length, col.hash_store_seed,
                                      col.bucket_info, col.num_buckets,
                                      col.codebook->max_codelength,
-                                     col.codebook->lookup_table);
+                                     col.codebook->code_length_counts,
+                                     col.codebook->ordered_symbols);
       }
     }
 


### PR DESCRIPTION
The per-codebook `HuffmanLookupTable<T>` allocates `2^max_codelength × sizeof(T)` bytes per CSF (and per column in MultisetCSF). At large N and max_codelength it can dominate RSS, and it's a micro-optimization on top of the already-cheap canonical decode. The query path now calls `canonicalDecodeFromNumber` directly — a handful of additional bit-shift loop iterations per query — and the codebook's memory footprint drops to just the code-length counts and ordered symbols.