### PR TITLE
Interleaved bucket-contiguous solution layout (-60% query latency)

### DIFF
--- a/cython/_caramel.pyx
+++ b/cython/_caramel.pyx
@@ -1092,13 +1092,13 @@ cdef class MultisetCSFUint32:
         return list(self._ptr.get().query(buf, length, parallel))
 
     def save(self, str filename):
-        self._ptr.get().save(filename.encode('utf-8'), 101)
+        self._ptr.get().save(filename.encode('utf-8'), 1101)
 
     @staticmethod
     def load(str filename):
         cdef MultisetCSFUint32 obj = MultisetCSFUint32.__new__(MultisetCSFUint32)
         try:
-            obj._ptr = cpp.MultisetCsf_uint32.load(filename.encode('utf-8'), 101)
+            obj._ptr = cpp.MultisetCsf_uint32.load(filename.encode('utf-8'), 1101)
         except RuntimeError as e:
             raise CsfDeserializationException(str(e))
         obj.permutation_seconds = 0.0
@@ -1161,13 +1161,13 @@ cdef class MultisetCSFUint64:
         return list(self._ptr.get().query(buf, length, parallel))
 
     def save(self, str filename):
-        self._ptr.get().save(filename.encode('utf-8'), 102)
+        self._ptr.get().save(filename.encode('utf-8'), 1102)
 
     @staticmethod
     def load(str filename):
         cdef MultisetCSFUint64 obj = MultisetCSFUint64.__new__(MultisetCSFUint64)
         try:
-            obj._ptr = cpp.MultisetCsf_uint64.load(filename.encode('utf-8'), 102)
+            obj._ptr = cpp.MultisetCsf_uint64.load(filename.encode('utf-8'), 1102)
         except RuntimeError as e:
             raise CsfDeserializationException(str(e))
         obj.permutation_seconds = 0.0
@@ -1222,13 +1222,13 @@ cdef class MultisetCSFChar10:
         return py_results
 
     def save(self, str filename):
-        self._ptr.get().save(filename.encode('utf-8'), 103)
+        self._ptr.get().save(filename.encode('utf-8'), 1103)
 
     @staticmethod
     def load(str filename):
         cdef MultisetCSFChar10 obj = MultisetCSFChar10.__new__(MultisetCSFChar10)
         try:
-            obj._ptr = cpp.MultisetCsf_Char10.load(filename.encode('utf-8'), 103)
+            obj._ptr = cpp.MultisetCsf_Char10.load(filename.encode('utf-8'), 1103)
         except RuntimeError as e:
             raise CsfDeserializationException(str(e))
         return obj
@@ -1281,13 +1281,13 @@ cdef class MultisetCSFChar12:
         return py_results
 
     def save(self, str filename):
-        self._ptr.get().save(filename.encode('utf-8'), 104)
+        self._ptr.get().save(filename.encode('utf-8'), 1104)
 
     @staticmethod
     def load(str filename):
         cdef MultisetCSFChar12 obj = MultisetCSFChar12.__new__(MultisetCSFChar12)
         try:
-            obj._ptr = cpp.MultisetCsf_Char12.load(filename.encode('utf-8'), 104)
+            obj._ptr = cpp.MultisetCsf_Char12.load(filename.encode('utf-8'), 1104)
         except RuntimeError as e:
             raise CsfDeserializationException(str(e))
         return obj
@@ -1341,13 +1341,13 @@ cdef class MultisetCSFString:
         return [result[i].decode('utf-8') for i in range(result.size())]
 
     def save(self, str filename):
-        self._ptr.get().save(filename.encode('utf-8'), 105)
+        self._ptr.get().save(filename.encode('utf-8'), 1105)
 
     @staticmethod
     def load(str filename):
         cdef MultisetCSFString obj = MultisetCSFString.__new__(MultisetCSFString)
         try:
-            obj._ptr = cpp.MultisetCsf_string.load(filename.encode('utf-8'), 105)
+            obj._ptr = cpp.MultisetCsf_string.load(filename.encode('utf-8'), 1105)
         except RuntimeError as e:
             raise CsfDeserializationException(str(e))
         return obj
@@ -1387,13 +1387,13 @@ cdef class RaggedMultisetCSFUint32:
         return list(self._ptr.get().query(buf, length))
 
     def save(self, str filename):
-        self._ptr.get().save(filename.encode('utf-8'), 301)
+        self._ptr.get().save(filename.encode('utf-8'), 1301)
 
     @staticmethod
     def load(str filename):
         cdef RaggedMultisetCSFUint32 obj = RaggedMultisetCSFUint32.__new__(RaggedMultisetCSFUint32)
         try:
-            obj._ptr = cpp.RaggedMultisetCsf_uint32.load(filename.encode('utf-8'), 301)
+            obj._ptr = cpp.RaggedMultisetCsf_uint32.load(filename.encode('utf-8'), 1301)
         except RuntimeError as e:
             raise CsfDeserializationException(str(e))
         return obj

--- a/python_tests/test_interleaved_layout.py
+++ b/python_tests/test_interleaved_layout.py
@@ -1,0 +1,110 @@
+"""Tests targeting the interleaved BucketArena layout and its build paths:
+heterogeneous-distribution groups (subgrouping by bucket count), mixed filter
+modes (multiple groups), the all-keys-filtered degenerate group, and large M
+(stresses the flat arena indexing)."""
+
+import carameldb
+import numpy as np
+
+
+def test_interleaved_heterogeneous_no_filter_group(tmp_path):
+    """Columns with very different value distributions land in one no-filter
+    group; subgrouping by target bucket count must still round-trip exactly."""
+    num_rows = 2000
+    rng = np.random.default_rng(7)
+    cols = [
+        np.full(num_rows, 5, dtype=np.uint32),               # constant
+        rng.integers(0, 4, size=num_rows, dtype=np.uint32),   # low entropy
+        rng.integers(0, num_rows, size=num_rows, dtype=np.uint32),  # high entropy
+    ]
+    values = np.stack(cols, axis=1)
+    keys = [f"key_{i}" for i in range(num_rows)]
+
+    csf = carameldb.Caramel(keys, values, verbose=False)
+    for key, row in zip(keys, values):
+        assert csf.query(key) == list(row)
+
+    save_file = str(tmp_path / "hetero.csf")
+    csf.save(save_file)
+    csf2 = carameldb.load(save_file)
+    for key, row in zip(keys, values):
+        assert csf2.query(key) == list(row)
+
+
+def test_interleaved_mixed_filter_modes_multiple_groups(tmp_path):
+    """shared_filter with columns of different most-common values produces
+    multiple filter groups; output_index routing must stay correct."""
+    num_rows = 600
+    rng = np.random.default_rng(11)
+    values = np.zeros((num_rows, 4), dtype=np.uint32)
+    # Column MCVs differ (0, 0, 7, 7) -> two shared-filter groups; a minority of
+    # rows carry off-MCV values so the columns are non-degenerate.
+    values[:, 2] = 7
+    values[:, 3] = 7
+    minority = rng.choice(num_rows, size=num_rows // 4, replace=False)
+    for r in minority:
+        values[r] = rng.integers(1, 20, size=4, dtype=np.uint32)
+
+    prefilter = carameldb.BinaryFuseFilterConfig(fingerprint_bits=12)
+    csf = carameldb.Caramel(
+        keys=[f"key_{i}" for i in range(num_rows)],
+        values=values,
+        prefilter=prefilter,
+        shared_filter=True,
+        verbose=False,
+    )
+    keys = [f"key_{i}" for i in range(num_rows)]
+    for key, row in zip(keys, values):
+        assert csf.query(key) == list(row)
+
+    save_file = str(tmp_path / "mixed.csf")
+    csf.save(save_file)
+    csf2 = carameldb.load(save_file)
+    for key, row in zip(keys, values):
+        assert csf2.query(key) == list(row)
+
+
+def test_interleaved_degenerate_all_keys_filtered(tmp_path):
+    """A group where every key matches the MCV produces a zero-bucket group.
+
+    With a constant column, the filter removes all keys, so the group has no
+    active keys / zero buckets. The degenerate path must still build, query,
+    and round-trip.
+    """
+    num_rows = 400
+    num_cols = 3
+    keys = [f"key_{i}" for i in range(num_rows)]
+    values = np.zeros((num_rows, num_cols), dtype=np.uint32)
+
+    prefilter = carameldb.BinaryFuseFilterConfig(fingerprint_bits=12)
+    csf = carameldb.Caramel(
+        keys, values, prefilter=prefilter, shared_filter=True, verbose=False
+    )
+    for key, row in zip(keys, values):
+        assert csf.query(key) == list(row)
+
+    save_file = str(tmp_path / "degenerate.csf")
+    csf.save(save_file)
+    csf2 = carameldb.load(save_file)
+    for key, row in zip(keys, values):
+        assert csf2.query(key) == list(row)
+
+
+def test_interleaved_large_m_correctness(tmp_path):
+    """Large M (256 columns) in one no-filter group exercises the flat arena
+    index arithmetic across many columns per bucket."""
+    num_rows = 300
+    num_cols = 256
+    rng = np.random.default_rng(13)
+    values = rng.integers(0, 50, size=(num_rows, num_cols), dtype=np.uint32)
+    keys = [f"key_{i}" for i in range(num_rows)]
+
+    csf = carameldb.Caramel(keys, values, verbose=False)
+    for key, row in zip(keys, values):
+        assert csf.query(key) == list(row)
+
+    save_file = str(tmp_path / "largem.csf")
+    csf.save(save_file)
+    csf2 = carameldb.load(save_file)
+    for key, row in zip(keys, values):
+        assert csf2.query(key) == list(row)

--- a/scripts/benchmark_multiset.py
+++ b/scripts/benchmark_multiset.py
@@ -123,6 +123,9 @@ def main():
     mmap_mode = "c" if args.permutation != "none" else "r"
     print(f"Loading {args.npy} (mmap mode={mmap_mode!r})...", flush=True)
     values = np.load(args.npy, mmap_mode=mmap_mode)
+    # Materialize into anonymous RAM so peak RSS isn't confounded by evictable
+    # mmap'd file pages (which vary with memory pressure, polluting the number).
+    values = np.ascontiguousarray(values)
     if values.ndim != 2:
         raise ValueError(f"Expected 2D array, got shape {values.shape}")
     N, M = values.shape

--- a/scripts/benchmark_multiset.py
+++ b/scripts/benchmark_multiset.py
@@ -18,7 +18,9 @@ import argparse
 import gc
 import json
 import os
+import resource
 import shutil
+import sys
 import tempfile
 import time
 
@@ -190,6 +192,12 @@ def main():
         args.query_sample, args.query_warmup, args.query_trials, args.seed,
     )
 
+    # Peak resident set of this process over the whole build+measure. ru_maxrss
+    # is bytes on macOS, kibibytes on Linux. Each benchmark runs in its own
+    # process, so this is the build's peak.
+    ru_maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    peak_rss_bytes = ru_maxrss if sys.platform == "darwin" else ru_maxrss * 1024
+
     metrics = {
         "npy": os.path.abspath(args.npy),
         "N": int(N),
@@ -207,6 +215,7 @@ def main():
         "size_bytes": int(size_bytes),
         "bits_per_key": round(bits_per_key, 3),
         "query_ns_median": round(query_ns, 1),
+        "peak_rss_bytes": peak_rss_bytes,
         "save_dir": os.path.abspath(args.save_dir) if args.save_dir else None,
     }
 
@@ -217,6 +226,7 @@ def main():
     print(f"Wall time        : {wall_s:.2f} s")
     print(f"Serialized size  : {size_bytes:,} bytes  ({bits_per_key:.2f} bits/key)")
     print(f"Query latency    : {query_ns:.1f} ns/query (median)")
+    print(f"Peak RSS         : {peak_rss_bytes / 1e6:.1f} MB")
 
     if args.output_json:
         os.makedirs(os.path.dirname(os.path.abspath(args.output_json)) or ".", exist_ok=True)

--- a/src/construct/BucketedHashStore.h
+++ b/src/construct/BucketedHashStore.h
@@ -100,6 +100,74 @@ BucketedHashStore<T> construct(const std::vector<std::string> &keys,
   return {key_buckets, value_buckets, seed, key_buckets.size()};
 }
 
+// A key partition computed once and reused to bucket many columns' values.
+// All columns of a multiset group share the same keys + seed, so hashing the
+// keys per column (the dominant build cost) is wasteful; hash once here and
+// scatter each column's values with scatterValues().
+struct KeyPartition {
+  std::vector<std::vector<__uint128_t>> key_buckets;  // signatures, grouped
+  std::vector<uint32_t> bucket_of_key;                // bucket id per key (input order)
+  uint64_t seed = 0;
+  uint32_t num_buckets = 0;
+};
+
+inline KeyPartition partitionKeys(const std::vector<std::string> &keys,
+                                  uint32_t num_buckets,
+                                  uint32_t num_attempts = 3) {
+  uint64_t approximate_bucket_size = keys.size() / num_buckets + 1;
+  for (uint64_t seed = 0; seed < num_attempts; seed++) {
+    KeyPartition part;
+    part.seed = seed;
+    part.num_buckets = num_buckets;
+    part.key_buckets.assign(num_buckets, {});
+    part.bucket_of_key.resize(keys.size());
+    for (uint32_t b = 0; b < num_buckets; b++) {
+      part.key_buckets[b].reserve(approximate_bucket_size);
+    }
+
+    for (size_t i = 0; i < keys.size(); i++) {
+      __uint128_t signature = hashKey(keys[i], seed);
+      uint32_t bucket_id = getBucketID(signature, num_buckets);
+      part.key_buckets[bucket_id].push_back(signature);
+      part.bucket_of_key[i] = bucket_id;
+    }
+
+    bool collision = false;
+#pragma omp parallel for default(none) shared(num_buckets, part, collision)
+    for (size_t b = 0; b < num_buckets; b++) {
+      const auto &bucket = part.key_buckets[b];
+      std::unordered_set<__uint128_t> uniques(bucket.begin(), bucket.end());
+      if (uniques.size() != bucket.size()) {
+#pragma omp critical
+        collision = true;
+      }
+    }
+    if (!collision) {
+      return part;
+    }
+    if (seed == num_attempts - 1) {
+      throw std::runtime_error("Detected a key collision under 128-bit hash. "
+                               "Likely due to a duplicate key.");
+    }
+  }
+  throw std::invalid_argument("Fatal error: should never reach here.");
+}
+
+// Buckets one column's values under a precomputed key partition (no hashing).
+template <typename T>
+std::vector<std::vector<T>> scatterValues(const std::vector<T> &values,
+                                          const KeyPartition &part) {
+  std::vector<std::vector<T>> value_buckets(part.num_buckets);
+  uint64_t approximate_bucket_size = values.size() / part.num_buckets + 1;
+  for (auto &vb : value_buckets) {
+    vb.reserve(approximate_bucket_size);
+  }
+  for (size_t i = 0; i < values.size(); i++) {
+    value_buckets[part.bucket_of_key[i]].push_back(values[i]);
+  }
+  return value_buckets;
+}
+
 template <typename T>
 BucketedHashStore<T> partitionToBuckets(const std::vector<std::string> &keys,
                                         const std::vector<T> &values,

--- a/src/construct/Construct.h
+++ b/src/construct/Construct.h
@@ -28,6 +28,27 @@ Arguments:
     Returns:
             SparseSystemPtr to solve for each key's encoded bits.
 */
+// Number of equations in a subsystem: the total coded bit-length of its values.
+// This sum is the single expensive codedict pass; for high-entropy data it is
+// ~one DRAM-bound lookup per value, so callers that already have it (e.g. the
+// arena size pass) should reuse it rather than recomputing.
+template <typename T>
+uint64_t subsystemNumEquations(const std::vector<T> &values,
+                               const CodeDict<T> &codedict) {
+  uint64_t num_equations = 0;
+  for (const auto &v : values) {
+    num_equations += codedict.find(v)->second.numBits();
+  }
+  return num_equations;
+}
+
+// Variables (solution columns) for a given equation count: equations scaled by
+// DELTA. The single formula the solver and the size pass both use.
+inline uint64_t numVariablesFromEquations(uint64_t num_equations, float DELTA) {
+  return static_cast<uint64_t>(
+      std::ceil(static_cast<double>(num_equations) * DELTA));
+}
+
 // The width of a subsystem's solution is fully determined by its values' code
 // lengths (not the key contents and not the solve seed): the number of
 // equations scaled by DELTA. Exposed so the arena layout can be sized before
@@ -35,22 +56,25 @@ Arguments:
 template <typename T>
 uint64_t subsystemNumVariables(const std::vector<T> &values,
                                const CodeDict<T> &codedict, float DELTA) {
-  uint64_t num_equations = 0;
-  for (const auto &v : values) {
-    num_equations += codedict.find(v)->second.numBits();
-  }
-  return std::ceil(static_cast<double>(num_equations) * DELTA);
+  return numVariablesFromEquations(subsystemNumEquations<T>(values, codedict),
+                                   DELTA);
 }
 
 // Total bits in a solved subsystem's BitArray: the variables plus the
 // max_codelength slack the decode's bit-slice reads past the last variable.
+inline uint32_t solutionBitsFromEquations(uint64_t num_equations,
+                                          uint32_t max_codelength, float DELTA) {
+  return static_cast<uint32_t>(
+             numVariablesFromEquations(num_equations, DELTA)) +
+         max_codelength;
+}
+
 template <typename T>
 uint32_t subsystemSolutionBits(const std::vector<T> &values,
                                const CodeDict<T> &codedict,
                                uint32_t max_codelength, float DELTA) {
-  return static_cast<uint32_t>(
-             subsystemNumVariables<T>(values, codedict, DELTA)) +
-         max_codelength;
+  return solutionBitsFromEquations(subsystemNumEquations<T>(values, codedict),
+                                   max_codelength, DELTA);
 }
 
 template <typename T>
@@ -58,13 +82,13 @@ SparseSystemPtr
 constructModulo2System(const std::vector<__uint128_t> &key_signatures,
                        const std::vector<T> &values,
                        const CodeDict<T> &codedict, uint32_t max_codelength,
-                       uint32_t seed, float DELTA) {
-  uint64_t num_variables = subsystemNumVariables<T>(values, codedict, DELTA);
-
-  uint64_t num_equations = 0;
-  for (const auto &v : values) {
-    num_equations += codedict.find(v)->second.numBits();
+                       uint32_t seed, float DELTA, uint64_t num_equations = 0) {
+  // num_equations == 0 means "not precomputed". A non-empty bucket always has a
+  // positive coded length, so the sentinel never collides with a real count.
+  if (num_equations == 0) {
+    num_equations = subsystemNumEquations<T>(values, codedict);
   }
+  uint64_t num_variables = numVariablesFromEquations(num_equations, DELTA);
 
   auto sparse_system =
       SparseSystem::make(num_equations, num_variables + max_codelength);
@@ -90,14 +114,15 @@ SubsystemSolutionSeedPair
 constructAndSolveSubsystem(const std::vector<__uint128_t> &key_signatures,
                            const std::vector<T> &values,
                            const CodeDict<T> &codedict, uint32_t max_codelength,
-                           float DELTA) {
+                           float DELTA, uint64_t num_equations = 0) {
   uint32_t seed = 0;
   uint32_t num_tries = 0;
   uint32_t max_num_attempts = 128;
   while (true) {
     try {
       SparseSystemPtr sparse_system = constructModulo2System<T>(
-          key_signatures, values, codedict, max_codelength, seed, DELTA);
+          key_signatures, values, codedict, max_codelength, seed, DELTA,
+          num_equations);
 
       BitArrayPtr solution = solveModulo2System(sparse_system);
 

--- a/src/construct/Construct.h
+++ b/src/construct/Construct.h
@@ -28,21 +28,43 @@ Arguments:
     Returns:
             SparseSystemPtr to solve for each key's encoded bits.
 */
+// The width of a subsystem's solution is fully determined by its values' code
+// lengths (not the key contents and not the solve seed): the number of
+// equations scaled by DELTA. Exposed so the arena layout can be sized before
+// solving, from the same formula the solver uses.
+template <typename T>
+uint64_t subsystemNumVariables(const std::vector<T> &values,
+                               const CodeDict<T> &codedict, float DELTA) {
+  uint64_t num_equations = 0;
+  for (const auto &v : values) {
+    num_equations += codedict.find(v)->second.numBits();
+  }
+  return std::ceil(static_cast<double>(num_equations) * DELTA);
+}
+
+// Total bits in a solved subsystem's BitArray: the variables plus the
+// max_codelength slack the decode's bit-slice reads past the last variable.
+template <typename T>
+uint32_t subsystemSolutionBits(const std::vector<T> &values,
+                               const CodeDict<T> &codedict,
+                               uint32_t max_codelength, float DELTA) {
+  return static_cast<uint32_t>(
+             subsystemNumVariables<T>(values, codedict, DELTA)) +
+         max_codelength;
+}
+
 template <typename T>
 SparseSystemPtr
 constructModulo2System(const std::vector<__uint128_t> &key_signatures,
                        const std::vector<T> &values,
                        const CodeDict<T> &codedict, uint32_t max_codelength,
                        uint32_t seed, float DELTA) {
+  uint64_t num_variables = subsystemNumVariables<T>(values, codedict, DELTA);
+
   uint64_t num_equations = 0;
   for (const auto &v : values) {
     num_equations += codedict.find(v)->second.numBits();
   }
-
-  // TODO(david) should we add max_codelength to num_variables, was getting a
-  // core dumped error
-  uint64_t num_variables =
-      std::ceil(static_cast<double>(num_equations) * DELTA);
 
   auto sparse_system =
       SparseSystem::make(num_equations, num_variables + max_codelength);

--- a/src/construct/ConstructUtils.h
+++ b/src/construct/ConstructUtils.h
@@ -9,6 +9,12 @@ namespace caramel {
 void inline signatureToEquation(const __uint128_t &signature,
                                 const uint64_t seed, uint64_t num_variables,
                                 uint64_t *e) {
+  if (num_variables == 0) {
+    // An empty bucket has no variables; __builtin_clzll(0) is undefined, so
+    // short-circuit. The caller decodes nothing from a zero-variable range.
+    e[0] = e[1] = e[2] = 0;
+    return;
+  }
   uint64_t hash[4];
   SpookyHash::SpookyShortRehash(signature, seed, hash);
   const int shift = __builtin_clzll(num_variables);

--- a/src/construct/CsfQueryCore.h
+++ b/src/construct/CsfQueryCore.h
@@ -13,23 +13,20 @@ struct BucketQueryInfo {
   uint32_t seed;
 };
 
+// Decodes one bucket's value for a key whose signature is already known. The
+// single source of the bit-slice + canonical-decode tail, shared by
+// queryCsfCore (single Csf) and MultisetCsf/RaggedMultisetCsf group queries.
 template <typename T>
-T queryCsfCore(const char *data, size_t length, uint32_t hash_store_seed,
-               const std::vector<BucketQueryInfo> &bucket_info,
-               uint32_t num_buckets, uint32_t max_codelength,
-               const std::vector<uint32_t> &code_length_counts,
-               const std::vector<T> &ordered_symbols) {
-  __uint128_t signature = hashKey(data, length, hash_store_seed);
-
-  uint32_t bucket_id = getBucketID(signature, num_buckets);
-
-  const auto &info = bucket_info[bucket_id];
-
+inline T __attribute__((always_inline))
+decodeBucketColumn(const __uint128_t &signature, const BucketQueryInfo &info,
+                   uint32_t max_codelength,
+                   const std::vector<uint32_t> &code_length_counts,
+                   const std::vector<T> &ordered_symbols) {
   uint64_t e[3];
   signatureToEquation(signature, info.seed, info.num_variables, e);
 
   const uint64_t *arr = info.data;
-  const int l = 64 - max_codelength;
+  const int l = 64 - static_cast<int>(max_codelength);
   auto getbits = [arr, l](uint32_t pos) __attribute__((always_inline)) {
     const uint64_t w = pos / 64;
     const int b = pos % 64;
@@ -42,6 +39,18 @@ T queryCsfCore(const char *data, size_t length, uint32_t hash_store_seed,
 
   return canonicalDecodeFromNumber<T>(encoded_value, code_length_counts,
                                       ordered_symbols, max_codelength);
+}
+
+template <typename T>
+T queryCsfCore(const char *data, size_t length, uint32_t hash_store_seed,
+               const std::vector<BucketQueryInfo> &bucket_info,
+               uint32_t num_buckets, uint32_t max_codelength,
+               const std::vector<uint32_t> &code_length_counts,
+               const std::vector<T> &ordered_symbols) {
+  __uint128_t signature = hashKey(data, length, hash_store_seed);
+  uint32_t bucket_id = getBucketID(signature, num_buckets);
+  return decodeBucketColumn<T>(signature, bucket_info[bucket_id], max_codelength,
+                               code_length_counts, ordered_symbols);
 }
 
 } // namespace caramel

--- a/src/construct/multiset/ConstructMultiset.h
+++ b/src/construct/multiset/ConstructMultiset.h
@@ -178,6 +178,212 @@ resolveColumnInputs(const std::vector<std::string> &all_keys,
   return {nullptr, {}, {}, std::nullopt};
 }
 
+// Per-column resolved state used while building groups.
+template <typename T>
+struct ResolvedColumn {
+  uint32_t col_index = 0;  // original output position
+  PreFilterPtr<T> filter;
+  std::optional<T> most_common_value;
+  std::vector<std::string> keys;  // active keys (filtered or full)
+  std::vector<T> values;          // active values
+  std::shared_ptr<CsfCodebook<T>> codebook;
+};
+
+// Packs solved per-(bucket, col) BitArrays into a flat interleaved arena.
+// Each (bucket, col) range is word-aligned (start bit % 64 == 0) so the
+// query path can reuse queryCsfCore's bit-slicing unchanged. Intra-bucket
+// padding is at most 63 bits per column — negligible vs per-column
+// BitArrayPtr allocations.
+template <typename T>
+void packArena(
+    typename MultisetCsf<T>::BucketArena &arena,
+    const std::vector<std::vector<SubsystemSolutionSeedPair>> &per_col_solutions,
+    uint32_t num_buckets) {
+  const uint32_t M = static_cast<uint32_t>(per_col_solutions.size());
+  arena.num_cols = M;
+  arena.num_buckets = num_buckets;
+  arena.bucket_offsets.assign(num_buckets + 1, 0);
+  arena.per_col_bits.assign(static_cast<size_t>(num_buckets) * M, 0);
+  arena.per_col_seeds.assign(static_cast<size_t>(num_buckets) * M, 0);
+
+  // First pass: compute padded bit length for each (bucket, col) and the
+  // bucket block offsets. Each sub-range is padded up to a 64-bit word
+  // boundary so word-indexed reads in queryCsfCore work directly.
+  uint64_t cursor_bits = 0;
+  std::vector<uint32_t> padded_bits(static_cast<size_t>(num_buckets) * M, 0);
+  for (uint32_t b = 0; b < num_buckets; b++) {
+    arena.bucket_offsets[b] = cursor_bits;
+    for (uint32_t c = 0; c < M; c++) {
+      const auto &[solution, seed] = per_col_solutions[c][b];
+      uint32_t bits = solution->numBits();
+      arena.per_col_bits[b * M + c] = bits;
+      arena.per_col_seeds[b * M + c] = seed;
+      uint32_t padded = (bits + 63u) & ~63u;
+      padded_bits[b * M + c] = padded;
+      cursor_bits += padded;
+    }
+  }
+  arena.bucket_offsets[num_buckets] = cursor_bits;
+
+  // Second pass: allocate and copy bits. Each sub-range starts word-aligned,
+  // so we can memcpy word-by-word from the BitArray's backing array.
+  uint64_t total_words = cursor_bits / 64;
+  arena.solution_bits.assign(total_words, 0);
+
+  for (uint32_t b = 0; b < num_buckets; b++) {
+    uint64_t bit_off = arena.bucket_offsets[b];
+    for (uint32_t c = 0; c < M; c++) {
+      const auto &solution = per_col_solutions[c][b].first;
+      uint32_t bits = solution->numBits();
+      uint32_t padded = padded_bits[b * M + c];
+      uint64_t word_off = bit_off / 64;
+      const uint64_t *src = solution->backingArrayPtr();
+      uint32_t src_words = (bits + 63u) / 64u;
+      std::copy(src, src + src_words, arena.solution_bits.data() + word_off);
+      bit_off += padded;
+    }
+  }
+}
+
+// Runs partitionToBuckets once for a group of columns that share active keys,
+// then solves each column's subsystems against that single hash store and
+// packs all solutions into a flat interleaved arena.
+template <typename T>
+typename MultisetCsf<T>::Group
+buildGroup(const std::vector<std::string> &active_keys,
+           const std::vector<ResolvedColumn<T> *> &group_cols,
+           bool shared_codebook) {
+  using GroupT = typename MultisetCsf<T>::Group;
+  using GroupColumnT = typename MultisetCsf<T>::GroupColumn;
+  GroupT group;
+
+  // Group-level num_buckets = max across member columns. This guarantees
+  // every column fits in the shared bucket layout.
+  uint64_t num_buckets = 0;
+  for (const auto *col : group_cols) {
+    uint64_t nb = targetBucketCount(col->values, col->codebook->codedict);
+    num_buckets = std::max(num_buckets, nb);
+  }
+
+  if (num_buckets == 0 || active_keys.empty()) {
+    // Degenerate group: all keys were filtered out for every column. Keep
+    // zero-bucket arena; query returns the most-common value per column.
+    group.num_buckets = 0;
+    group.hash_store_seed = 0;
+    group.arena.num_cols = static_cast<uint32_t>(group_cols.size());
+    group.arena.num_buckets = 0;
+    group.columns.reserve(group_cols.size());
+    for (const auto *col : group_cols) {
+      GroupColumnT gc;
+      gc.output_index = col->col_index;
+      gc.codebook = col->codebook;
+      gc.filter = col->filter;
+      gc.most_common_value = col->most_common_value;
+      gc.uses_shared_codebook = shared_codebook;
+      gc.max_codelength = col->codebook ? col->codebook->max_codelength : 0;
+      group.columns.push_back(std::move(gc));
+    }
+    return group;
+  }
+
+  // Per-column hash stores share a seed and bucket layout. We build one
+  // BucketedHashStore per column (each column may have different values
+  // for the same key, so value_buckets differ), but all share the same
+  // key partitioning because active_keys is identical across the group.
+  std::vector<BucketedHashStore<T>> per_col_stores(group_cols.size());
+  uint64_t chosen_seed = 0;
+  {
+    // Try partitioning with the first column's values to pick a seed that
+    // passes the collision check. The collision check only depends on the
+    // 128-bit key hashes, so any column's values will accept the same seed.
+    per_col_stores[0] = partitionToBuckets<T>(active_keys, group_cols[0]->values,
+                                              num_buckets);
+    chosen_seed = per_col_stores[0].seed;
+  }
+  for (size_t i = 1; i < group_cols.size(); i++) {
+    // Reuse the chosen seed; rebuild buckets with column i's values. This
+    // guarantees all columns see the same key-to-bucket assignment.
+    per_col_stores[i] = construct<T>(
+        active_keys, group_cols[i]->values, num_buckets, chosen_seed,
+        active_keys.size() / num_buckets + 1);
+  }
+
+  // Solve each column's subsystems (bucket-parallel within each column).
+  const uint32_t M = static_cast<uint32_t>(group_cols.size());
+  std::vector<std::vector<SubsystemSolutionSeedPair>> per_col_solutions(M);
+
+  for (uint32_t c = 0; c < M; c++) {
+    per_col_solutions[c].assign(num_buckets, {});
+    const auto &store = per_col_stores[c];
+    const CodeDict<T> &codedict = group_cols[c]->codebook->codedict;
+    uint32_t max_cl = group_cols[c]->codebook->max_codelength;
+    std::exception_ptr exception = nullptr;
+
+#pragma omp parallel for default(none)                                         \
+    shared(store, per_col_solutions, c, exception, codedict, max_cl, DELTA,    \
+           num_buckets)
+    for (uint32_t j = 0; j < num_buckets; j++) {
+      if (exception) {
+        continue;
+      }
+      try {
+        per_col_solutions[c][j] = constructAndSolveSubsystem<T>(
+            store.key_buckets[j], store.value_buckets[j], codedict, max_cl,
+            DELTA);
+      } catch (std::exception &) {
+#pragma omp critical
+        { exception = std::current_exception(); }
+      }
+    }
+
+    if (exception) {
+      std::rethrow_exception(exception);
+    }
+  }
+
+  group.hash_store_seed = static_cast<uint32_t>(chosen_seed);
+  group.num_buckets = static_cast<uint32_t>(num_buckets);
+  packArena<T>(group.arena, per_col_solutions,
+               static_cast<uint32_t>(num_buckets));
+
+  group.columns.reserve(M);
+  for (const auto *col : group_cols) {
+    GroupColumnT gc;
+    gc.output_index = col->col_index;
+    gc.codebook = col->codebook;
+    gc.filter = col->filter;
+    gc.most_common_value = col->most_common_value;
+    gc.uses_shared_codebook = shared_codebook;
+    gc.max_codelength = col->codebook->max_codelength;
+    group.columns.push_back(std::move(gc));
+  }
+  return group;
+}
+
+// Groups resolved columns by their shared active-key set. Columns share a
+// group iff (a) they share the same filter pointer (or all have nullptr), and
+// (b) they have identical active_keys (invariant guaranteed by construction:
+// same filter ⇒ same filtered key set; no filter ⇒ full key set).
+template <typename T>
+std::vector<std::vector<ResolvedColumn<T> *>>
+groupColumnsByActiveKeys(std::vector<ResolvedColumn<T>> &cols) {
+  std::unordered_map<const void *, std::vector<ResolvedColumn<T> *>> by_filter;
+  std::vector<const void *> order;  // preserve first-seen order
+  for (auto &col : cols) {
+    const void *key = col.filter.get();  // nullptr allowed
+    if (by_filter.find(key) == by_filter.end()) {
+      order.push_back(key);
+    }
+    by_filter[key].push_back(&col);
+  }
+  std::vector<std::vector<ResolvedColumn<T> *>> groups;
+  groups.reserve(order.size());
+  for (const void *key : order) {
+    groups.push_back(std::move(by_filter[key]));
+  }
+  return groups;
+}
+
 template <typename T>
 MultisetCsfPtr<T>
 constructMultisetCsf(const std::vector<std::string> &keys,
@@ -214,67 +420,35 @@ constructMultisetCsf(const std::vector<std::string> &keys,
     group_filters = buildGroupSharedFilters<T>(keys, values, config.filter_config, config.verbose);
   }
 
-  using ColumnState = typename MultisetCsf<T>::ColumnState;
-  std::vector<ColumnState> columns(num_columns);
-
+  std::vector<ResolvedColumn<T>> resolved(num_columns);
   for (size_t i = 0; i < num_columns; i++) {
     auto *col_filter = group_filters.empty() ? nullptr : &group_filters[i];
     auto col_inputs = resolveColumnInputs<T>(
         keys, values[i], col_filter, config.filter_config, config.verbose);
 
     bool using_filter = (col_inputs.filter != nullptr);
-    const auto &active_keys = using_filter ? col_inputs.keys : keys;
-    const auto &active_values = using_filter ? col_inputs.values : values[i];
-
-    auto col_codebook = config.shared_codebook
+    resolved[i].col_index = static_cast<uint32_t>(i);
+    resolved[i].filter = col_inputs.filter;
+    resolved[i].most_common_value = col_inputs.most_common_value;
+    resolved[i].keys = using_filter ? std::move(col_inputs.keys) : keys;
+    resolved[i].values =
+        using_filter ? std::move(col_inputs.values) : std::move(values[i]);
+    resolved[i].codebook = config.shared_codebook
         ? shared_cb
-        : std::make_shared<CsfCodebook<T>>(canonicalHuffman<T>(active_values));
-
-    const CodeDict<T> &codedict = col_codebook->codedict;
-    uint32_t max_cl = col_codebook->max_codelength;
-
-    uint64_t num_buckets = targetBucketCount(active_values, codedict);
-
-    BucketedHashStore<T> hash_store =
-        partitionToBuckets<T>(active_keys, active_values, num_buckets);
-
-    std::exception_ptr exception = nullptr;
-    std::vector<SubsystemSolutionSeedPair> solutions_and_seeds(
-        hash_store.num_buckets);
-
-#pragma omp parallel for default(none)                                         \
-    shared(hash_store, solutions_and_seeds, exception, DELTA,                  \
-           codedict, max_cl)
-    for (uint32_t j = 0; j < hash_store.num_buckets; j++) {
-      if (exception) {
-        continue;
-      }
-      try {
-        solutions_and_seeds[j] = constructAndSolveSubsystem<T>(
-            hash_store.key_buckets[j], hash_store.value_buckets[j],
-            codedict, max_cl, DELTA);
-      } catch (std::exception &e) {
-#pragma omp critical
-        {
-          exception = std::current_exception();
-        }
-      }
-    }
-
-    if (exception) {
-      std::rethrow_exception(exception);
-    }
-
-    columns[i].solutions_and_seeds = std::move(solutions_and_seeds);
-    columns[i].hash_store_seed = hash_store.seed;
-    columns[i].codebook = col_codebook;
-    columns[i].uses_shared_codebook = config.shared_codebook;
-    columns[i].filter = col_inputs.filter;
-    columns[i].most_common_value = col_inputs.most_common_value;
-    columns[i].buildQueryCache();
+        : std::make_shared<CsfCodebook<T>>(canonicalHuffman<T>(resolved[i].values));
   }
 
-  return std::make_shared<MultisetCsf<T>>(std::move(columns), shared_cb);
+  auto col_groups = groupColumnsByActiveKeys<T>(resolved);
+  std::vector<typename MultisetCsf<T>::Group> groups;
+  groups.reserve(col_groups.size());
+  for (auto &group_cols : col_groups) {
+    const auto &active_keys = group_cols.front()->keys;
+    groups.push_back(buildGroup<T>(active_keys, group_cols,
+                                    config.shared_codebook));
+  }
+
+  return std::make_shared<MultisetCsf<T>>(
+      std::move(groups), static_cast<uint32_t>(num_columns), shared_cb);
 }
 
 template <typename T>
@@ -383,8 +557,7 @@ constructMultisetCsfRowMajor(const std::vector<std::string> &keys,
                                                config.verbose);
   }
 
-  using ColumnState = typename MultisetCsf<T>::ColumnState;
-  std::vector<ColumnState> columns(num_columns);
+  std::vector<ResolvedColumn<T>> resolved(num_columns);
   std::vector<T> column_values(n);
 
   for (size_t i = 0; i < num_columns; i++) {
@@ -397,59 +570,29 @@ constructMultisetCsfRowMajor(const std::vector<std::string> &keys,
         keys, column_values, col_filter, config.filter_config, config.verbose);
 
     bool using_filter = (col_inputs.filter != nullptr);
-    const auto &active_keys = using_filter ? col_inputs.keys : keys;
-    const auto &active_values = using_filter ? col_inputs.values : column_values;
-
-    auto col_codebook = config.shared_codebook
+    resolved[i].col_index = static_cast<uint32_t>(i);
+    resolved[i].filter = col_inputs.filter;
+    resolved[i].most_common_value = col_inputs.most_common_value;
+    resolved[i].keys = using_filter ? std::move(col_inputs.keys) : keys;
+    resolved[i].values =
+        using_filter ? std::move(col_inputs.values) : column_values;
+    resolved[i].codebook = config.shared_codebook
         ? shared_cb
-        : std::make_shared<CsfCodebook<T>>(canonicalHuffman<T>(active_values));
+        : std::make_shared<CsfCodebook<T>>(canonicalHuffman<T>(resolved[i].values));
+  }
 
-    const CodeDict<T> &codedict = col_codebook->codedict;
-    uint32_t max_cl = col_codebook->max_codelength;
-
-    uint64_t num_buckets = targetBucketCount(active_values, codedict);
-
-    BucketedHashStore<T> hash_store =
-        partitionToBuckets<T>(active_keys, active_values, num_buckets);
-
-    std::exception_ptr exception = nullptr;
-    std::vector<SubsystemSolutionSeedPair> solutions_and_seeds(
-        hash_store.num_buckets);
-
-#pragma omp parallel for default(none)                                         \
-    shared(hash_store, solutions_and_seeds, exception, DELTA,                  \
-           codedict, max_cl)
-    for (uint32_t j = 0; j < hash_store.num_buckets; j++) {
-      if (exception) {
-        continue;
-      }
-      try {
-        solutions_and_seeds[j] = constructAndSolveSubsystem<T>(
-            hash_store.key_buckets[j], hash_store.value_buckets[j],
-            codedict, max_cl, DELTA);
-      } catch (std::exception &e) {
-#pragma omp critical
-        {
-          exception = std::current_exception();
-        }
-      }
-    }
-
-    if (exception) {
-      std::rethrow_exception(exception);
-    }
-
-    columns[i].solutions_and_seeds = std::move(solutions_and_seeds);
-    columns[i].hash_store_seed = hash_store.seed;
-    columns[i].codebook = col_codebook;
-    columns[i].uses_shared_codebook = config.shared_codebook;
-    columns[i].filter = col_inputs.filter;
-    columns[i].most_common_value = col_inputs.most_common_value;
-    columns[i].buildQueryCache();
+  auto col_groups = groupColumnsByActiveKeys<T>(resolved);
+  std::vector<typename MultisetCsf<T>::Group> groups;
+  groups.reserve(col_groups.size());
+  for (auto &group_cols : col_groups) {
+    const auto &active_keys = group_cols.front()->keys;
+    groups.push_back(buildGroup<T>(active_keys, group_cols,
+                                    config.shared_codebook));
   }
 
   result.build_seconds = timer.seconds();
-  result.csf = std::make_shared<MultisetCsf<T>>(std::move(columns), shared_cb);
+  result.csf = std::make_shared<MultisetCsf<T>>(
+      std::move(groups), static_cast<uint32_t>(num_columns), shared_cb);
   return result;
 }
 

--- a/src/construct/multiset/ConstructMultiset.h
+++ b/src/construct/multiset/ConstructMultiset.h
@@ -231,18 +231,23 @@ void fillArena(
   arena.per_col_word_off.assign(cells, 0);
 
   // Size pass: a subsystem's solution width is fixed by its bucketed values
-  // before solving, so the entire bucket-major layout is known up front.
-  uint64_t total_words = 0;
+  // before solving, so the whole layout is known up front. The per-cell width
+  // (a codedict summation) is independent, so compute it in parallel; the
+  // bucket-major word offsets are then a cheap serial prefix sum.
+#pragma omp parallel for collapse(2) default(none)                            \
+    shared(value_buckets_per_col, codebooks, arena, num_buckets, M, DELTA)
   for (uint32_t b = 0; b < num_buckets; b++) {
     for (uint32_t c = 0; c < M; c++) {
       size_t idx = static_cast<size_t>(b) * M + c;
-      uint32_t bits = subsystemSolutionBits<T>(
+      arena.per_col_bits[idx] = subsystemSolutionBits<T>(
           value_buckets_per_col[c][b], codebooks[c]->codedict,
           codebooks[c]->max_codelength, DELTA);
-      arena.per_col_bits[idx] = bits;
-      arena.per_col_word_off[idx] = total_words;
-      total_words += (bits + 63u) / 64u;
     }
+  }
+  uint64_t total_words = 0;
+  for (size_t idx = 0; idx < cells; idx++) {
+    arena.per_col_word_off[idx] = total_words;
+    total_words += (arena.per_col_bits[idx] + 63u) / 64u;
   }
   // +1 trailing guard word: decode getbits() reads arr[w] and arr[w+1].
   arena.solution_bits.assign(total_words + 1, 0);
@@ -329,21 +334,24 @@ buildGroup(const std::vector<std::string> &active_keys,
   // key signatures.
   const uint32_t M = static_cast<uint32_t>(group_cols.size());
 
-  BucketedHashStore<T> base =
-      partitionToBuckets<T>(active_keys, group_cols[0]->values, num_buckets);
-  uint64_t chosen_seed = base.seed;
-  std::vector<std::vector<__uint128_t>> key_buckets =
-      std::move(base.key_buckets);
+  // Hash the keys ONCE (the dominant build cost) and reuse that partition to
+  // bucket every column's values in parallel, instead of re-hashing the same
+  // keys M times.
+  KeyPartition part =
+      partitionKeys(active_keys, static_cast<uint32_t>(num_buckets));
+  uint64_t chosen_seed = part.seed;
 
   std::vector<std::vector<std::vector<T>>> value_buckets_per_col(M);
-  value_buckets_per_col[0] = std::move(base.value_buckets);
-  for (uint32_t c = 1; c < M; c++) {
-    BucketedHashStore<T> store =
-        construct<T>(active_keys, group_cols[c]->values, num_buckets,
-                     chosen_seed, active_keys.size() / num_buckets + 1);
-    value_buckets_per_col[c] = std::move(store.value_buckets);
-    // store.key_buckets (identical to the shared partition) is freed here.
+#pragma omp parallel for default(none)                                        \
+    shared(value_buckets_per_col, group_cols, part, M)
+  for (uint32_t c = 0; c < M; c++) {
+    value_buckets_per_col[c] = scatterValues<T>(group_cols[c]->values, part);
   }
+  // Source values are now redundant with their bucketed copies; release them.
+  for (uint32_t c = 0; c < M; c++) {
+    group_cols[c]->values = std::vector<T>();
+  }
+  std::vector<std::vector<__uint128_t>> &key_buckets = part.key_buckets;
 
   std::vector<std::shared_ptr<CsfCodebook<T>>> codebooks;
   codebooks.reserve(M);

--- a/src/construct/multiset/ConstructMultiset.h
+++ b/src/construct/multiset/ConstructMultiset.h
@@ -7,6 +7,7 @@
 #include "src/construct/multiset/MultisetConfig.h"
 #include "src/construct/filter/FilterFactory.h"
 #include "src/utils/Timer.h"
+#include <cassert>
 #include <iostream>
 #include <omp.h>
 
@@ -189,59 +190,93 @@ struct ResolvedColumn {
   std::shared_ptr<CsfCodebook<T>> codebook;
 };
 
-// Packs solved per-(bucket, col) BitArrays into a flat interleaved arena.
-// Each (bucket, col) range is word-aligned (start bit % 64 == 0) so the
-// query path can reuse queryCsfCore's bit-slicing unchanged. Intra-bucket
-// padding is at most 63 bits per column — negligible vs per-column
-// BitArrayPtr allocations.
+// Codebook for one column. A column whose keys were all filtered out has no
+// active values to encode, so it gets a null codebook (and a zero-bucket
+// degenerate group) rather than feeding canonicalHuffman an empty input.
 template <typename T>
-void packArena(
+std::shared_ptr<CsfCodebook<T>>
+columnCodebook(const std::vector<T> &values, bool shared,
+               const std::shared_ptr<CsfCodebook<T>> &shared_cb) {
+  if (shared) {
+    return shared_cb;
+  }
+  if (values.empty()) {
+    return nullptr;
+  }
+  return std::make_shared<CsfCodebook<T>>(canonicalHuffman<T>(values));
+}
+
+// Builds the interleaved arena in place: sizes the whole bucket-major layout
+// from the (already partitioned) per-column value buckets, allocates it once,
+// then solves every (bucket, col) subsystem directly into its precomputed,
+// word-aligned slot. Each solution BitArray is freed as it leaves scope; the
+// arena is never held alongside a full second copy of the solution bits (the
+// old solve-then-pack was, costing ~2x peak memory at scale). key_buckets is
+// the shared key partition, identical across the group's columns. The value
+// buckets are released when the group finishes (not per-cell, to avoid
+// hammering the allocator from inside the parallel region).
+template <typename T>
+void fillArena(
     typename MultisetCsf<T>::BucketArena &arena,
-    const std::vector<std::vector<SubsystemSolutionSeedPair>> &per_col_solutions,
-    uint32_t num_buckets) {
-  const uint32_t M = static_cast<uint32_t>(per_col_solutions.size());
+    const std::vector<std::vector<__uint128_t>> &key_buckets,
+    std::vector<std::vector<std::vector<T>>> &value_buckets_per_col,
+    const std::vector<std::shared_ptr<CsfCodebook<T>>> &codebooks,
+    uint32_t num_buckets, float DELTA) {
+  const uint32_t M = static_cast<uint32_t>(value_buckets_per_col.size());
+  const size_t cells = static_cast<size_t>(num_buckets) * M;
   arena.num_cols = M;
   arena.num_buckets = num_buckets;
-  arena.bucket_offsets.assign(num_buckets + 1, 0);
-  arena.per_col_bits.assign(static_cast<size_t>(num_buckets) * M, 0);
-  arena.per_col_seeds.assign(static_cast<size_t>(num_buckets) * M, 0);
+  arena.per_col_bits.assign(cells, 0);
+  arena.per_col_seeds.assign(cells, 0);
+  arena.per_col_word_off.assign(cells, 0);
 
-  // First pass: compute padded bit length for each (bucket, col) and the
-  // bucket block offsets. Each sub-range is padded up to a 64-bit word
-  // boundary so word-indexed reads in queryCsfCore work directly.
-  uint64_t cursor_bits = 0;
-  std::vector<uint32_t> padded_bits(static_cast<size_t>(num_buckets) * M, 0);
+  // Size pass: a subsystem's solution width is fixed by its bucketed values
+  // before solving, so the entire bucket-major layout is known up front.
+  uint64_t total_words = 0;
   for (uint32_t b = 0; b < num_buckets; b++) {
-    arena.bucket_offsets[b] = cursor_bits;
     for (uint32_t c = 0; c < M; c++) {
-      const auto &[solution, seed] = per_col_solutions[c][b];
-      uint32_t bits = solution->numBits();
-      arena.per_col_bits[b * M + c] = bits;
-      arena.per_col_seeds[b * M + c] = seed;
-      uint32_t padded = (bits + 63u) & ~63u;
-      padded_bits[b * M + c] = padded;
-      cursor_bits += padded;
+      size_t idx = static_cast<size_t>(b) * M + c;
+      uint32_t bits = subsystemSolutionBits<T>(
+          value_buckets_per_col[c][b], codebooks[c]->codedict,
+          codebooks[c]->max_codelength, DELTA);
+      arena.per_col_bits[idx] = bits;
+      arena.per_col_word_off[idx] = total_words;
+      total_words += (bits + 63u) / 64u;
     }
   }
-  arena.bucket_offsets[num_buckets] = cursor_bits;
+  // +1 trailing guard word: decode getbits() reads arr[w] and arr[w+1].
+  arena.solution_bits.assign(total_words + 1, 0);
 
-  // Second pass: allocate and copy bits. Each sub-range starts word-aligned,
-  // so we can memcpy word-by-word from the BitArray's backing array.
-  uint64_t total_words = cursor_bits / 64;
-  arena.solution_bits.assign(total_words, 0);
-
+  // Solve pass: each (bucket, col) writes into its own disjoint, precomputed
+  // slot, so no lock is needed for the copy (only for exception capture).
+  uint64_t *out = arena.solution_bits.data();
+  std::exception_ptr exception = nullptr;
+#pragma omp parallel for collapse(2) default(none)                            \
+    shared(key_buckets, value_buckets_per_col, codebooks, arena, out,         \
+           exception, num_buckets, M, DELTA)
   for (uint32_t b = 0; b < num_buckets; b++) {
-    uint64_t bit_off = arena.bucket_offsets[b];
     for (uint32_t c = 0; c < M; c++) {
-      const auto &solution = per_col_solutions[c][b].first;
-      uint32_t bits = solution->numBits();
-      uint32_t padded = padded_bits[b * M + c];
-      uint64_t word_off = bit_off / 64;
-      const uint64_t *src = solution->backingArrayPtr();
-      uint32_t src_words = (bits + 63u) / 64u;
-      std::copy(src, src + src_words, arena.solution_bits.data() + word_off);
-      bit_off += padded;
+      if (exception) {
+        continue;
+      }
+      try {
+        size_t idx = static_cast<size_t>(b) * M + c;
+        auto [solution, seed] = constructAndSolveSubsystem<T>(
+            key_buckets[b], value_buckets_per_col[c][b], codebooks[c]->codedict,
+            codebooks[c]->max_codelength, DELTA);
+        assert(solution->numBits() == arena.per_col_bits[idx]);
+        arena.per_col_seeds[idx] = seed;
+        const uint64_t *src = solution->backingArrayPtr();
+        std::copy(src, src + (arena.per_col_bits[idx] + 63u) / 64u,
+                  out + arena.per_col_word_off[idx]);
+      } catch (std::exception &) {
+#pragma omp critical
+        { exception = std::current_exception(); }
+      }
     }
+  }
+  if (exception) {
+    std::rethrow_exception(exception);
   }
 }
 
@@ -261,14 +296,15 @@ buildGroup(const std::vector<std::string> &active_keys,
   // every column fits in the shared bucket layout.
   uint64_t num_buckets = 0;
   for (const auto *col : group_cols) {
-    uint64_t nb = targetBucketCount(col->values, col->codebook->codedict);
+    uint64_t nb = col->codebook
+                      ? targetBucketCount(col->values, col->codebook->codedict)
+                      : 0;
     num_buckets = std::max(num_buckets, nb);
   }
 
   if (num_buckets == 0 || active_keys.empty()) {
     // Degenerate group: all keys were filtered out for every column. Keep
     // zero-bucket arena; query returns the most-common value per column.
-    group.num_buckets = 0;
     group.hash_store_seed = 0;
     group.arena.num_cols = static_cast<uint32_t>(group_cols.size());
     group.arena.num_buckets = 0;
@@ -286,65 +322,38 @@ buildGroup(const std::vector<std::string> &active_keys,
     return group;
   }
 
-  // Per-column hash stores share a seed and bucket layout. We build one
-  // BucketedHashStore per column (each column may have different values
-  // for the same key, so value_buckets differ), but all share the same
-  // key partitioning because active_keys is identical across the group.
-  std::vector<BucketedHashStore<T>> per_col_stores(group_cols.size());
-  uint64_t chosen_seed = 0;
-  {
-    // Try partitioning with the first column's values to pick a seed that
-    // passes the collision check. The collision check only depends on the
-    // 128-bit key hashes, so any column's values will accept the same seed.
-    per_col_stores[0] = partitionToBuckets<T>(active_keys, group_cols[0]->values,
-                                              num_buckets);
-    chosen_seed = per_col_stores[0].seed;
-  }
-  for (size_t i = 1; i < group_cols.size(); i++) {
-    // Reuse the chosen seed; rebuild buckets with column i's values. This
-    // guarantees all columns see the same key-to-bucket assignment.
-    per_col_stores[i] = construct<T>(
-        active_keys, group_cols[i]->values, num_buckets, chosen_seed,
-        active_keys.size() / num_buckets + 1);
-  }
-
-  // Solve each column's subsystems (bucket-parallel within each column).
+  // All columns of the group share the same key partition (identical
+  // active_keys + seed), so partition the keys once and reuse that assignment
+  // for every column; only the per-column values differ. We hold one shared
+  // key_buckets plus each column's value_buckets — never M copies of the large
+  // key signatures.
   const uint32_t M = static_cast<uint32_t>(group_cols.size());
-  std::vector<std::vector<SubsystemSolutionSeedPair>> per_col_solutions(M);
 
-  for (uint32_t c = 0; c < M; c++) {
-    per_col_solutions[c].assign(num_buckets, {});
-    const auto &store = per_col_stores[c];
-    const CodeDict<T> &codedict = group_cols[c]->codebook->codedict;
-    uint32_t max_cl = group_cols[c]->codebook->max_codelength;
-    std::exception_ptr exception = nullptr;
+  BucketedHashStore<T> base =
+      partitionToBuckets<T>(active_keys, group_cols[0]->values, num_buckets);
+  uint64_t chosen_seed = base.seed;
+  std::vector<std::vector<__uint128_t>> key_buckets =
+      std::move(base.key_buckets);
 
-#pragma omp parallel for default(none)                                         \
-    shared(store, per_col_solutions, c, exception, codedict, max_cl, DELTA,    \
-           num_buckets)
-    for (uint32_t j = 0; j < num_buckets; j++) {
-      if (exception) {
-        continue;
-      }
-      try {
-        per_col_solutions[c][j] = constructAndSolveSubsystem<T>(
-            store.key_buckets[j], store.value_buckets[j], codedict, max_cl,
-            DELTA);
-      } catch (std::exception &) {
-#pragma omp critical
-        { exception = std::current_exception(); }
-      }
-    }
+  std::vector<std::vector<std::vector<T>>> value_buckets_per_col(M);
+  value_buckets_per_col[0] = std::move(base.value_buckets);
+  for (uint32_t c = 1; c < M; c++) {
+    BucketedHashStore<T> store =
+        construct<T>(active_keys, group_cols[c]->values, num_buckets,
+                     chosen_seed, active_keys.size() / num_buckets + 1);
+    value_buckets_per_col[c] = std::move(store.value_buckets);
+    // store.key_buckets (identical to the shared partition) is freed here.
+  }
 
-    if (exception) {
-      std::rethrow_exception(exception);
-    }
+  std::vector<std::shared_ptr<CsfCodebook<T>>> codebooks;
+  codebooks.reserve(M);
+  for (const auto *col : group_cols) {
+    codebooks.push_back(col->codebook);
   }
 
   group.hash_store_seed = static_cast<uint32_t>(chosen_seed);
-  group.num_buckets = static_cast<uint32_t>(num_buckets);
-  packArena<T>(group.arena, per_col_solutions,
-               static_cast<uint32_t>(num_buckets));
+  fillArena<T>(group.arena, key_buckets, value_buckets_per_col, codebooks,
+               static_cast<uint32_t>(num_buckets), DELTA);
 
   group.columns.reserve(M);
   for (const auto *col : group_cols) {
@@ -382,6 +391,39 @@ groupColumnsByActiveKeys(std::vector<ResolvedColumn<T>> &cols) {
     groups.push_back(std::move(by_filter[key]));
   }
   return groups;
+}
+
+// Splits a filter-group into sub-groups of columns that want a similar bucket
+// count. Every column in a group shares one num_buckets (the group max) so a
+// query computes one bucket id and streams the bucket's columns contiguously;
+// without this split one high-entropy column would force the rest to
+// over-partition, inflating build time. Columns are binned so the max/min
+// target bucket count within a sub-group stays within kBucketRatio.
+template <typename T>
+std::vector<std::vector<ResolvedColumn<T> *>>
+subGroupByBucketCount(const std::vector<ResolvedColumn<T> *> &group_cols) {
+  constexpr uint64_t kBucketRatio = 2;
+  std::vector<std::pair<uint64_t, ResolvedColumn<T> *>> with_nb;
+  with_nb.reserve(group_cols.size());
+  for (auto *col : group_cols) {
+    uint64_t nb = col->codebook
+                      ? targetBucketCount(col->values, col->codebook->codedict)
+                      : 0;
+    with_nb.emplace_back(nb, col);
+  }
+  std::sort(with_nb.begin(), with_nb.end(),
+            [](const auto &a, const auto &b) { return a.first < b.first; });
+
+  std::vector<std::vector<ResolvedColumn<T> *>> sub_groups;
+  uint64_t sub_min = 0;
+  for (auto &[nb, col] : with_nb) {
+    if (sub_groups.empty() || nb > sub_min * kBucketRatio) {
+      sub_groups.push_back({});
+      sub_min = nb;
+    }
+    sub_groups.back().push_back(col);
+  }
+  return sub_groups;
 }
 
 template <typename T>
@@ -430,21 +472,26 @@ constructMultisetCsf(const std::vector<std::string> &keys,
     resolved[i].col_index = static_cast<uint32_t>(i);
     resolved[i].filter = col_inputs.filter;
     resolved[i].most_common_value = col_inputs.most_common_value;
-    resolved[i].keys = using_filter ? std::move(col_inputs.keys) : keys;
+    // No-filter columns share the full key set, so leave ResolvedColumn::keys
+    // empty and let buildGroup fall back to the shared `keys` reference
+    // (zero-copy). Only filtered columns own a distinct key subset.
+    if (using_filter) {
+      resolved[i].keys = std::move(col_inputs.keys);
+    }
     resolved[i].values =
         using_filter ? std::move(col_inputs.values) : std::move(values[i]);
-    resolved[i].codebook = config.shared_codebook
-        ? shared_cb
-        : std::make_shared<CsfCodebook<T>>(canonicalHuffman<T>(resolved[i].values));
+    resolved[i].codebook =
+        columnCodebook<T>(resolved[i].values, config.shared_codebook, shared_cb);
   }
 
-  auto col_groups = groupColumnsByActiveKeys<T>(resolved);
   std::vector<typename MultisetCsf<T>::Group> groups;
-  groups.reserve(col_groups.size());
-  for (auto &group_cols : col_groups) {
-    const auto &active_keys = group_cols.front()->keys;
-    groups.push_back(buildGroup<T>(active_keys, group_cols,
-                                    config.shared_codebook));
+  for (auto &filter_group : groupColumnsByActiveKeys<T>(resolved)) {
+    for (auto &group_cols : subGroupByBucketCount<T>(filter_group)) {
+      const auto &active_keys =
+          group_cols.front()->filter ? group_cols.front()->keys : keys;
+      groups.push_back(
+          buildGroup<T>(active_keys, group_cols, config.shared_codebook));
+    }
   }
 
   return std::make_shared<MultisetCsf<T>>(
@@ -573,21 +620,25 @@ constructMultisetCsfRowMajor(const std::vector<std::string> &keys,
     resolved[i].col_index = static_cast<uint32_t>(i);
     resolved[i].filter = col_inputs.filter;
     resolved[i].most_common_value = col_inputs.most_common_value;
-    resolved[i].keys = using_filter ? std::move(col_inputs.keys) : keys;
+    // No-filter columns share the full key set, so leave keys empty and let
+    // the call site fall back to the shared `keys` reference (zero-copy).
+    if (using_filter) {
+      resolved[i].keys = std::move(col_inputs.keys);
+    }
     resolved[i].values =
         using_filter ? std::move(col_inputs.values) : column_values;
-    resolved[i].codebook = config.shared_codebook
-        ? shared_cb
-        : std::make_shared<CsfCodebook<T>>(canonicalHuffman<T>(resolved[i].values));
+    resolved[i].codebook =
+        columnCodebook<T>(resolved[i].values, config.shared_codebook, shared_cb);
   }
 
-  auto col_groups = groupColumnsByActiveKeys<T>(resolved);
   std::vector<typename MultisetCsf<T>::Group> groups;
-  groups.reserve(col_groups.size());
-  for (auto &group_cols : col_groups) {
-    const auto &active_keys = group_cols.front()->keys;
-    groups.push_back(buildGroup<T>(active_keys, group_cols,
-                                    config.shared_codebook));
+  for (auto &filter_group : groupColumnsByActiveKeys<T>(resolved)) {
+    for (auto &group_cols : subGroupByBucketCount<T>(filter_group)) {
+      const auto &active_keys =
+          group_cols.front()->filter ? group_cols.front()->keys : keys;
+      groups.push_back(
+          buildGroup<T>(active_keys, group_cols, config.shared_codebook));
+    }
   }
 
   result.build_seconds = timer.seconds();

--- a/src/construct/multiset/ConstructMultiset.h
+++ b/src/construct/multiset/ConstructMultiset.h
@@ -8,6 +8,7 @@
 #include "src/construct/filter/FilterFactory.h"
 #include "src/utils/Timer.h"
 #include <cassert>
+#include <cstdlib>
 #include <iostream>
 #include <omp.h>
 
@@ -230,18 +231,27 @@ void fillArena(
   arena.per_col_seeds.assign(cells, 0);
   arena.per_col_word_off.assign(cells, 0);
 
+  // The codedict summation (one DRAM-bound lookup per value for high-entropy
+  // data) is the single expensive sizing pass. Compute it once here, keep the
+  // per-cell equation count, and hand it to the solver so it never re-sums.
+  std::vector<uint64_t> per_cell_equations(cells, 0);
+
+  Timer size_timer;
   // Size pass: a subsystem's solution width is fixed by its bucketed values
   // before solving, so the whole layout is known up front. The per-cell width
-  // (a codedict summation) is independent, so compute it in parallel; the
-  // bucket-major word offsets are then a cheap serial prefix sum.
+  // is independent, so compute it in parallel; the bucket-major word offsets
+  // are then a cheap serial prefix sum.
 #pragma omp parallel for collapse(2) default(none)                            \
-    shared(value_buckets_per_col, codebooks, arena, num_buckets, M, DELTA)
+    shared(value_buckets_per_col, codebooks, arena, per_cell_equations,        \
+           num_buckets, M, DELTA)
   for (uint32_t b = 0; b < num_buckets; b++) {
     for (uint32_t c = 0; c < M; c++) {
       size_t idx = static_cast<size_t>(b) * M + c;
-      arena.per_col_bits[idx] = subsystemSolutionBits<T>(
-          value_buckets_per_col[c][b], codebooks[c]->codedict,
-          codebooks[c]->max_codelength, DELTA);
+      uint64_t eqs = subsystemNumEquations<T>(value_buckets_per_col[c][b],
+                                              codebooks[c]->codedict);
+      per_cell_equations[idx] = eqs;
+      arena.per_col_bits[idx] = solutionBitsFromEquations(
+          eqs, codebooks[c]->max_codelength, DELTA);
     }
   }
   uint64_t total_words = 0;
@@ -252,13 +262,17 @@ void fillArena(
   // +1 trailing guard word: decode getbits() reads arr[w] and arr[w+1].
   arena.solution_bits.assign(total_words + 1, 0);
 
+  const bool timing = std::getenv("CARAMEL_TIMING") != nullptr;
+  double size_s = size_timer.seconds();
+  Timer solve_timer;
+
   // Solve pass: each (bucket, col) writes into its own disjoint, precomputed
   // slot, so no lock is needed for the copy (only for exception capture).
   uint64_t *out = arena.solution_bits.data();
   std::exception_ptr exception = nullptr;
 #pragma omp parallel for collapse(2) default(none)                            \
     shared(key_buckets, value_buckets_per_col, codebooks, arena, out,         \
-           exception, num_buckets, M, DELTA)
+           exception, per_cell_equations, num_buckets, M, DELTA)
   for (uint32_t b = 0; b < num_buckets; b++) {
     for (uint32_t c = 0; c < M; c++) {
       if (exception) {
@@ -268,7 +282,7 @@ void fillArena(
         size_t idx = static_cast<size_t>(b) * M + c;
         auto [solution, seed] = constructAndSolveSubsystem<T>(
             key_buckets[b], value_buckets_per_col[c][b], codebooks[c]->codedict,
-            codebooks[c]->max_codelength, DELTA);
+            codebooks[c]->max_codelength, DELTA, per_cell_equations[idx]);
         assert(solution->numBits() == arena.per_col_bits[idx]);
         arena.per_col_seeds[idx] = seed;
         const uint64_t *src = solution->backingArrayPtr();
@@ -282,6 +296,12 @@ void fillArena(
   }
   if (exception) {
     std::rethrow_exception(exception);
+  }
+  if (timing) {
+    std::cerr << "[timing] fillArena M=" << M << " num_buckets=" << num_buckets
+              << " cells=" << cells << " words=" << total_words
+              << " size_pass=" << size_s
+              << "s solve_pass=" << solve_timer.seconds() << "s\n";
   }
 }
 
@@ -337,15 +357,24 @@ buildGroup(const std::vector<std::string> &active_keys,
   // Hash the keys ONCE (the dominant build cost) and reuse that partition to
   // bucket every column's values in parallel, instead of re-hashing the same
   // keys M times.
+  const bool timing = std::getenv("CARAMEL_TIMING") != nullptr;
+  Timer part_timer;
   KeyPartition part =
       partitionKeys(active_keys, static_cast<uint32_t>(num_buckets));
   uint64_t chosen_seed = part.seed;
+  double partition_s = part_timer.seconds();
 
+  Timer scatter_timer;
   std::vector<std::vector<std::vector<T>>> value_buckets_per_col(M);
 #pragma omp parallel for default(none)                                        \
     shared(value_buckets_per_col, group_cols, part, M)
   for (uint32_t c = 0; c < M; c++) {
     value_buckets_per_col[c] = scatterValues<T>(group_cols[c]->values, part);
+  }
+  if (timing) {
+    std::cerr << "[timing] buildGroup M=" << M << " keys=" << active_keys.size()
+              << " partition=" << partition_s
+              << "s scatter=" << scatter_timer.seconds() << "s\n";
   }
   // Source values are now redundant with their bucketed copies; release them.
   for (uint32_t c = 0; c < M; c++) {

--- a/src/construct/multiset/ConstructMultiset.h
+++ b/src/construct/multiset/ConstructMultiset.h
@@ -207,23 +207,24 @@ columnCodebook(const std::vector<T> &values, bool shared,
   return std::make_shared<CsfCodebook<T>>(canonicalHuffman<T>(values));
 }
 
-// Builds the interleaved arena in place: sizes the whole bucket-major layout
-// from the (already partitioned) per-column value buckets, allocates it once,
-// then solves every (bucket, col) subsystem directly into its precomputed,
-// word-aligned slot. Each solution BitArray is freed as it leaves scope; the
-// arena is never held alongside a full second copy of the solution bits (the
-// old solve-then-pack was, costing ~2x peak memory at scale). key_buckets is
-// the shared key partition, identical across the group's columns. The value
-// buckets are released when the group finishes (not per-cell, to avoid
-// hammering the allocator from inside the parallel region).
+// Builds the interleaved arena in place, streaming one column at a time so peak
+// memory stays ~1x: the whole bucket-major layout is sized directly from the
+// shared key partition (no bucketed value copy needed to size), the arena is
+// allocated once, then each column scatters its source values, solves every
+// bucket into its precomputed word-aligned slot, and frees its values before
+// the next column. At most O(threads) columns' value buckets and O(threads)
+// solution BitArrays are ever resident -- never all M columns at once, and
+// never a second full copy of the solution bits (the old solve-then-pack was,
+// costing ~2x peak at scale). `part` is the shared key partition (identical
+// across the group's columns); source_values_per_col[c] is consumed in place.
 template <typename T>
 void fillArena(
-    typename MultisetCsf<T>::BucketArena &arena,
-    const std::vector<std::vector<__uint128_t>> &key_buckets,
-    std::vector<std::vector<std::vector<T>>> &value_buckets_per_col,
+    typename MultisetCsf<T>::BucketArena &arena, const KeyPartition &part,
+    std::vector<std::vector<T>> &source_values_per_col,
     const std::vector<std::shared_ptr<CsfCodebook<T>>> &codebooks,
-    uint32_t num_buckets, float DELTA) {
-  const uint32_t M = static_cast<uint32_t>(value_buckets_per_col.size());
+    float DELTA) {
+  const uint32_t M = static_cast<uint32_t>(source_values_per_col.size());
+  const uint32_t num_buckets = part.num_buckets;
   const size_t cells = static_cast<size_t>(num_buckets) * M;
   arena.num_cols = M;
   arena.num_buckets = num_buckets;
@@ -235,23 +236,28 @@ void fillArena(
   // data) is the single expensive sizing pass. Compute it once here, keep the
   // per-cell equation count, and hand it to the solver so it never re-sums.
   std::vector<uint64_t> per_cell_equations(cells, 0);
+  const std::vector<uint32_t> &bucket_of_key = part.bucket_of_key;
 
   Timer size_timer;
-  // Size pass: a subsystem's solution width is fixed by its bucketed values
-  // before solving, so the whole layout is known up front. The per-cell width
-  // is independent, so compute it in parallel; the bucket-major word offsets
-  // are then a cheap serial prefix sum.
-#pragma omp parallel for collapse(2) default(none)                            \
-    shared(value_buckets_per_col, codebooks, arena, per_cell_equations,        \
-           num_buckets, M, DELTA)
-  for (uint32_t b = 0; b < num_buckets; b++) {
-    for (uint32_t c = 0; c < M; c++) {
+  // Size pass: a subsystem's width is the coded bit-length of its bucket's
+  // values, which we accumulate straight from each column's source values via
+  // bucket_of_key -- no bucketed copy required. Columns are independent (each
+  // writes only its own cells idx = b*M + c), so parallelize over them.
+#pragma omp parallel for schedule(dynamic, 1) default(none)                    \
+    shared(source_values_per_col, codebooks, arena, per_cell_equations,        \
+           bucket_of_key, num_buckets, M, DELTA)
+  for (uint32_t c = 0; c < M; c++) {
+    const auto &codedict = codebooks[c]->codedict;
+    const auto &vals = source_values_per_col[c];
+    std::vector<uint64_t> eqs(num_buckets, 0);
+    for (size_t i = 0; i < vals.size(); i++) {
+      eqs[bucket_of_key[i]] += codedict.find(vals[i])->second.numBits();
+    }
+    for (uint32_t b = 0; b < num_buckets; b++) {
       size_t idx = static_cast<size_t>(b) * M + c;
-      uint64_t eqs = subsystemNumEquations<T>(value_buckets_per_col[c][b],
-                                              codebooks[c]->codedict);
-      per_cell_equations[idx] = eqs;
-      arena.per_col_bits[idx] = solutionBitsFromEquations(
-          eqs, codebooks[c]->max_codelength, DELTA);
+      per_cell_equations[idx] = eqs[b];
+      arena.per_col_bits[idx] =
+          solutionBitsFromEquations(eqs[b], codebooks[c]->max_codelength, DELTA);
     }
   }
   uint64_t total_words = 0;
@@ -266,41 +272,52 @@ void fillArena(
   double size_s = size_timer.seconds();
   Timer solve_timer;
 
-  // Solve pass: each (bucket, col) writes into its own disjoint, precomputed
-  // slot, so no lock is needed for the copy (only for exception capture).
+  // Solve pass: one column at a time (parallel over columns). Each column
+  // scatters its source values into buckets -- aligned with part.key_buckets,
+  // since both preserve input order within a bucket -- solves each bucket into
+  // its disjoint arena slot, then frees its values. Disjoint slots need no lock
+  // (only exception capture does).
   uint64_t *out = arena.solution_bits.data();
   std::exception_ptr exception = nullptr;
-#pragma omp parallel for collapse(2) default(none)                            \
-    shared(key_buckets, value_buckets_per_col, codebooks, arena, out,         \
-           exception, per_cell_equations, num_buckets, M, DELTA)
-  for (uint32_t b = 0; b < num_buckets; b++) {
-    for (uint32_t c = 0; c < M; c++) {
-      if (exception) {
-        continue;
-      }
-      try {
+#pragma omp parallel for schedule(dynamic, 1) default(none)                    \
+    shared(source_values_per_col, codebooks, arena, out, exception,            \
+           per_cell_equations, part, num_buckets, M, DELTA)
+  for (uint32_t c = 0; c < M; c++) {
+    if (exception) {
+      continue;
+    }
+    try {
+      std::vector<std::vector<T>> value_buckets =
+          scatterValues<T>(source_values_per_col[c], part);
+      source_values_per_col[c] = std::vector<T>();
+      const auto &codedict = codebooks[c]->codedict;
+      uint32_t max_cl = codebooks[c]->max_codelength;
+      for (uint32_t b = 0; b < num_buckets; b++) {
         size_t idx = static_cast<size_t>(b) * M + c;
         auto [solution, seed] = constructAndSolveSubsystem<T>(
-            key_buckets[b], value_buckets_per_col[c][b], codebooks[c]->codedict,
-            codebooks[c]->max_codelength, DELTA, per_cell_equations[idx]);
+            part.key_buckets[b], value_buckets[b], codedict, max_cl, DELTA,
+            per_cell_equations[idx]);
         assert(solution->numBits() == arena.per_col_bits[idx]);
         arena.per_col_seeds[idx] = seed;
         const uint64_t *src = solution->backingArrayPtr();
         std::copy(src, src + (arena.per_col_bits[idx] + 63u) / 64u,
                   out + arena.per_col_word_off[idx]);
-      } catch (std::exception &) {
-#pragma omp critical
-        { exception = std::current_exception(); }
       }
+    } catch (std::exception &) {
+#pragma omp critical
+      { exception = std::current_exception(); }
     }
   }
   if (exception) {
     std::rethrow_exception(exception);
   }
   if (timing) {
+    uint64_t arena_bytes =
+        static_cast<uint64_t>(arena.solution_bits.size()) * 8 +
+        static_cast<uint64_t>(cells) * (4 + 4 + 8); // bits + seeds + word_off
     std::cerr << "[timing] fillArena M=" << M << " num_buckets=" << num_buckets
               << " cells=" << cells << " words=" << total_words
-              << " size_pass=" << size_s
+              << " arena=" << arena_bytes / 1e9 << "GB size_pass=" << size_s
               << "s solve_pass=" << solve_timer.seconds() << "s\n";
   }
 }
@@ -354,9 +371,10 @@ buildGroup(const std::vector<std::string> &active_keys,
   // key signatures.
   const uint32_t M = static_cast<uint32_t>(group_cols.size());
 
-  // Hash the keys ONCE (the dominant build cost) and reuse that partition to
-  // bucket every column's values in parallel, instead of re-hashing the same
-  // keys M times.
+  // Hash the keys ONCE (the dominant build cost) and reuse that partition for
+  // every column, instead of re-hashing the same keys M times. fillArena then
+  // scatters + solves one column at a time, so we never materialize all M
+  // columns' bucketed values at once.
   const bool timing = std::getenv("CARAMEL_TIMING") != nullptr;
   Timer part_timer;
   KeyPartition part =
@@ -364,23 +382,12 @@ buildGroup(const std::vector<std::string> &active_keys,
   uint64_t chosen_seed = part.seed;
   double partition_s = part_timer.seconds();
 
-  Timer scatter_timer;
-  std::vector<std::vector<std::vector<T>>> value_buckets_per_col(M);
-#pragma omp parallel for default(none)                                        \
-    shared(value_buckets_per_col, group_cols, part, M)
+  // Move each column's source values into a compact per-column buffer; fillArena
+  // consumes (and frees) them one column at a time.
+  std::vector<std::vector<T>> source_values_per_col(M);
   for (uint32_t c = 0; c < M; c++) {
-    value_buckets_per_col[c] = scatterValues<T>(group_cols[c]->values, part);
+    source_values_per_col[c] = std::move(group_cols[c]->values);
   }
-  if (timing) {
-    std::cerr << "[timing] buildGroup M=" << M << " keys=" << active_keys.size()
-              << " partition=" << partition_s
-              << "s scatter=" << scatter_timer.seconds() << "s\n";
-  }
-  // Source values are now redundant with their bucketed copies; release them.
-  for (uint32_t c = 0; c < M; c++) {
-    group_cols[c]->values = std::vector<T>();
-  }
-  std::vector<std::vector<__uint128_t>> &key_buckets = part.key_buckets;
 
   std::vector<std::shared_ptr<CsfCodebook<T>>> codebooks;
   codebooks.reserve(M);
@@ -388,9 +395,21 @@ buildGroup(const std::vector<std::string> &active_keys,
     codebooks.push_back(col->codebook);
   }
 
+  if (timing) {
+    uint64_t kb_bytes = 0;
+    for (const auto &bkt : part.key_buckets)
+      kb_bytes += static_cast<uint64_t>(bkt.capacity()) * sizeof(__uint128_t);
+    uint64_t cb_entries = 0;
+    for (const auto *col : group_cols)
+      if (col->codebook)
+        cb_entries += col->codebook->codedict.size();
+    std::cerr << "[timing] buildGroup M=" << M << " keys=" << active_keys.size()
+              << " partition=" << partition_s << "s key_buckets=" << kb_bytes / 1e9
+              << "GB codedict_entries=" << cb_entries << "\n";
+  }
+
   group.hash_store_seed = static_cast<uint32_t>(chosen_seed);
-  fillArena<T>(group.arena, key_buckets, value_buckets_per_col, codebooks,
-               static_cast<uint32_t>(num_buckets), DELTA);
+  fillArena<T>(group.arena, part, source_values_per_col, codebooks, DELTA);
 
   group.columns.reserve(M);
   for (const auto *col : group_cols) {

--- a/src/construct/multiset/ConstructMultiset.h
+++ b/src/construct/multiset/ConstructMultiset.h
@@ -228,7 +228,7 @@ void fillArena(
     std::vector<std::vector<T>> &source_values_per_col,
     const std::vector<std::shared_ptr<CsfCodebook<T>>> &codebooks,
     const std::vector<uint32_t> &col_indices, const T *data, size_t num_columns,
-    float DELTA) {
+    bool codebooks_disposable, float DELTA) {
   const uint32_t M = static_cast<uint32_t>(source_values_per_col.size());
   const uint32_t num_buckets = part.num_buckets;
   const size_t cells = static_cast<size_t>(num_buckets) * M;
@@ -303,7 +303,7 @@ void fillArena(
 #pragma omp parallel for schedule(dynamic, 1) default(none)                    \
     shared(source_values_per_col, codebooks, arena, out, exception,            \
            per_cell_equations, part, col_indices, data, num_columns, n,        \
-           num_buckets, M, DELTA)
+           num_buckets, M, codebooks_disposable, DELTA)
   for (uint32_t c = 0; c < M; c++) {
     if (exception) {
       continue;
@@ -334,6 +334,14 @@ void fillArena(
         const uint64_t *src = solution->backingArrayPtr();
         std::copy(src, src + (arena.per_col_bits[idx] + 63u) / 64u,
                   out + arena.per_col_word_off[idx]);
+      }
+      // The value->code map is construction-only (queries decode via
+      // ordered_symbols; codedict is never serialized). When these codebooks
+      // aren't shared with other columns, drop it as soon as the column is
+      // solved so the fat map shrinks during the solve -- this both lowers the
+      // build peak and leaves the served index ~codedict-free.
+      if (codebooks_disposable) {
+        codebooks[c]->codedict = CodeDict<T>();
       }
     } catch (std::exception &) {
 #pragma omp critical
@@ -443,8 +451,12 @@ buildGroup(const std::vector<std::string> &active_keys,
   }
 
   group.hash_store_seed = static_cast<uint32_t>(chosen_seed);
+  // Per-column codebooks are unique to their column, so fillArena may free each
+  // codedict as it finishes. A shared codebook is reused across columns/groups,
+  // so it must outlive the whole build (freed once at the end by the caller).
   fillArena<T>(group.arena, part, source_values_per_col, codebooks, col_indices,
-               data, num_columns, DELTA);
+               data, num_columns, /*codebooks_disposable=*/!shared_codebook,
+               DELTA);
 
   group.columns.reserve(M);
   for (const auto *col : group_cols) {
@@ -585,6 +597,12 @@ constructMultisetCsf(const std::vector<std::string> &keys,
       groups.push_back(
           buildGroup<T>(active_keys, group_cols, config.shared_codebook));
     }
+  }
+
+  // Shared codebook reused across groups; free its construction-only codedict
+  // now that every group is solved (queries never touch it).
+  if (config.shared_codebook && shared_cb) {
+    shared_cb->codedict = CodeDict<T>();
   }
 
   return std::make_shared<MultisetCsf<T>>(
@@ -743,6 +761,13 @@ constructMultisetCsfRowMajor(const std::vector<std::string> &keys,
       groups.push_back(buildGroup<T>(active_keys, group_cols,
                                      config.shared_codebook, data, num_columns));
     }
+  }
+
+  // A shared codebook is reused across all groups, so it's freed here (once all
+  // groups are solved) rather than progressively inside fillArena. codedict is
+  // construction-only; queries never touch it.
+  if (config.shared_codebook && shared_cb) {
+    shared_cb->codedict = CodeDict<T>();
   }
 
   result.build_seconds = timer.seconds();

--- a/src/construct/multiset/ConstructMultiset.h
+++ b/src/construct/multiset/ConstructMultiset.h
@@ -187,8 +187,13 @@ struct ResolvedColumn {
   PreFilterPtr<T> filter;
   std::optional<T> most_common_value;
   std::vector<std::string> keys;  // active keys (filtered or full)
-  std::vector<T> values;          // active values
+  std::vector<T> values;          // active values (may be left empty for
+                                  // no-filter columns, re-extracted on demand
+                                  // from the row-major buffer to avoid holding
+                                  // all M columns' values at once)
   std::shared_ptr<CsfCodebook<T>> codebook;
+  uint64_t num_buckets = 0;       // precomputed so grouping/build never re-read
+                                  // values just to size buckets
 };
 
 // Codebook for one column. A column whose keys were all filtered out has no
@@ -222,6 +227,7 @@ void fillArena(
     typename MultisetCsf<T>::BucketArena &arena, const KeyPartition &part,
     std::vector<std::vector<T>> &source_values_per_col,
     const std::vector<std::shared_ptr<CsfCodebook<T>>> &codebooks,
+    const std::vector<uint32_t> &col_indices, const T *data, size_t num_columns,
     float DELTA) {
   const uint32_t M = static_cast<uint32_t>(source_values_per_col.size());
   const uint32_t num_buckets = part.num_buckets;
@@ -237,18 +243,33 @@ void fillArena(
   // per-cell equation count, and hand it to the solver so it never re-sums.
   std::vector<uint64_t> per_cell_equations(cells, 0);
   const std::vector<uint32_t> &bucket_of_key = part.bucket_of_key;
+  const size_t n = bucket_of_key.size();
 
   Timer size_timer;
   // Size pass: a subsystem's width is the coded bit-length of its bucket's
   // values, which we accumulate straight from each column's source values via
-  // bucket_of_key -- no bucketed copy required. Columns are independent (each
-  // writes only its own cells idx = b*M + c), so parallelize over them.
+  // bucket_of_key -- no bucketed copy required. A column's values are either
+  // provided (filtered columns) or re-extracted on demand from the row-major
+  // `data` buffer (no-filter columns, so we never hold all M at once). Columns
+  // are independent (each writes only its own cells idx = b*M + c), so
+  // parallelize over them.
 #pragma omp parallel for schedule(dynamic, 1) default(none)                    \
     shared(source_values_per_col, codebooks, arena, per_cell_equations,        \
-           bucket_of_key, num_buckets, M, DELTA)
+           bucket_of_key, col_indices, data, num_columns, n, num_buckets, M,   \
+           DELTA)
   for (uint32_t c = 0; c < M; c++) {
+    std::vector<T> owned;
+    const std::vector<T> *valsp = &source_values_per_col[c];
+    if (valsp->empty() && n > 0) {
+      owned.resize(n);
+      uint32_t ci = col_indices[c];
+      for (size_t r = 0; r < n; r++) {
+        owned[r] = data[r * num_columns + ci];
+      }
+      valsp = &owned;
+    }
     const auto &codedict = codebooks[c]->codedict;
-    const auto &vals = source_values_per_col[c];
+    const auto &vals = *valsp;
     std::vector<uint64_t> eqs(num_buckets, 0);
     for (size_t i = 0; i < vals.size(); i++) {
       eqs[bucket_of_key[i]] += codedict.find(vals[i])->second.numBits();
@@ -281,15 +302,26 @@ void fillArena(
   std::exception_ptr exception = nullptr;
 #pragma omp parallel for schedule(dynamic, 1) default(none)                    \
     shared(source_values_per_col, codebooks, arena, out, exception,            \
-           per_cell_equations, part, num_buckets, M, DELTA)
+           per_cell_equations, part, col_indices, data, num_columns, n,        \
+           num_buckets, M, DELTA)
   for (uint32_t c = 0; c < M; c++) {
     if (exception) {
       continue;
     }
     try {
-      std::vector<std::vector<T>> value_buckets =
-          scatterValues<T>(source_values_per_col[c], part);
+      std::vector<T> owned;
+      const std::vector<T> *valsp = &source_values_per_col[c];
+      if (valsp->empty() && n > 0) {
+        owned.resize(n);
+        uint32_t ci = col_indices[c];
+        for (size_t r = 0; r < n; r++) {
+          owned[r] = data[r * num_columns + ci];
+        }
+        valsp = &owned;
+      }
+      std::vector<std::vector<T>> value_buckets = scatterValues<T>(*valsp, part);
       source_values_per_col[c] = std::vector<T>();
+      owned = std::vector<T>();
       const auto &codedict = codebooks[c]->codedict;
       uint32_t max_cl = codebooks[c]->max_codelength;
       for (uint32_t b = 0; b < num_buckets; b++) {
@@ -329,19 +361,17 @@ template <typename T>
 typename MultisetCsf<T>::Group
 buildGroup(const std::vector<std::string> &active_keys,
            const std::vector<ResolvedColumn<T> *> &group_cols,
-           bool shared_codebook) {
+           bool shared_codebook, const T *data = nullptr,
+           size_t num_columns = 0) {
   using GroupT = typename MultisetCsf<T>::Group;
   using GroupColumnT = typename MultisetCsf<T>::GroupColumn;
   GroupT group;
 
-  // Group-level num_buckets = max across member columns. This guarantees
-  // every column fits in the shared bucket layout.
+  // Group-level num_buckets = max across member columns (precomputed at resolve
+  // time). This guarantees every column fits in the shared bucket layout.
   uint64_t num_buckets = 0;
   for (const auto *col : group_cols) {
-    uint64_t nb = col->codebook
-                      ? targetBucketCount(col->values, col->codebook->codedict)
-                      : 0;
-    num_buckets = std::max(num_buckets, nb);
+    num_buckets = std::max(num_buckets, col->num_buckets);
   }
 
   if (num_buckets == 0 || active_keys.empty()) {
@@ -382,11 +412,15 @@ buildGroup(const std::vector<std::string> &active_keys,
   uint64_t chosen_seed = part.seed;
   double partition_s = part_timer.seconds();
 
-  // Move each column's source values into a compact per-column buffer; fillArena
-  // consumes (and frees) them one column at a time.
+  // Hand each column's values to fillArena, which consumes them one column at a
+  // time. Columns that resolved to stored values (filtered columns) are moved
+  // in; no-filter columns are left empty and re-extracted on demand from `data`
+  // by fillArena, so all M columns' values are never resident at once.
   std::vector<std::vector<T>> source_values_per_col(M);
+  std::vector<uint32_t> col_indices(M);
   for (uint32_t c = 0; c < M; c++) {
     source_values_per_col[c] = std::move(group_cols[c]->values);
+    col_indices[c] = group_cols[c]->col_index;
   }
 
   std::vector<std::shared_ptr<CsfCodebook<T>>> codebooks;
@@ -409,7 +443,8 @@ buildGroup(const std::vector<std::string> &active_keys,
   }
 
   group.hash_store_seed = static_cast<uint32_t>(chosen_seed);
-  fillArena<T>(group.arena, part, source_values_per_col, codebooks, DELTA);
+  fillArena<T>(group.arena, part, source_values_per_col, codebooks, col_indices,
+               data, num_columns, DELTA);
 
   group.columns.reserve(M);
   for (const auto *col : group_cols) {
@@ -462,10 +497,7 @@ subGroupByBucketCount(const std::vector<ResolvedColumn<T> *> &group_cols) {
   std::vector<std::pair<uint64_t, ResolvedColumn<T> *>> with_nb;
   with_nb.reserve(group_cols.size());
   for (auto *col : group_cols) {
-    uint64_t nb = col->codebook
-                      ? targetBucketCount(col->values, col->codebook->codedict)
-                      : 0;
-    with_nb.emplace_back(nb, col);
+    with_nb.emplace_back(col->num_buckets, col);
   }
   std::sort(with_nb.begin(), with_nb.end(),
             [](const auto &a, const auto &b) { return a.first < b.first; });
@@ -538,6 +570,11 @@ constructMultisetCsf(const std::vector<std::string> &keys,
         using_filter ? std::move(col_inputs.values) : std::move(values[i]);
     resolved[i].codebook =
         columnCodebook<T>(resolved[i].values, config.shared_codebook, shared_cb);
+    resolved[i].num_buckets =
+        resolved[i].codebook
+            ? targetBucketCount(resolved[i].values,
+                                resolved[i].codebook->codedict)
+            : 0;
   }
 
   std::vector<typename MultisetCsf<T>::Group> groups;
@@ -681,10 +718,21 @@ constructMultisetCsfRowMajor(const std::vector<std::string> &keys,
     if (using_filter) {
       resolved[i].keys = std::move(col_inputs.keys);
     }
-    resolved[i].values =
-        using_filter ? std::move(col_inputs.values) : column_values;
+    // Codebook + bucket count are computed now, from the active values. For
+    // no-filter columns we then drop the values (left empty) -- buildGroup
+    // re-extracts them column-by-column from `data`, so we never hold all M
+    // columns' values at once. Filtered columns keep their (smaller) values.
+    const std::vector<T> &active_values =
+        using_filter ? col_inputs.values : column_values;
     resolved[i].codebook =
-        columnCodebook<T>(resolved[i].values, config.shared_codebook, shared_cb);
+        columnCodebook<T>(active_values, config.shared_codebook, shared_cb);
+    resolved[i].num_buckets =
+        resolved[i].codebook
+            ? targetBucketCount(active_values, resolved[i].codebook->codedict)
+            : 0;
+    if (using_filter) {
+      resolved[i].values = std::move(col_inputs.values);
+    }
   }
 
   std::vector<typename MultisetCsf<T>::Group> groups;
@@ -692,8 +740,8 @@ constructMultisetCsfRowMajor(const std::vector<std::string> &keys,
     for (auto &group_cols : subGroupByBucketCount<T>(filter_group)) {
       const auto &active_keys =
           group_cols.front()->filter ? group_cols.front()->keys : keys;
-      groups.push_back(
-          buildGroup<T>(active_keys, group_cols, config.shared_codebook));
+      groups.push_back(buildGroup<T>(active_keys, group_cols,
+                                     config.shared_codebook, data, num_columns));
     }
   }
 

--- a/src/construct/multiset/ConstructRaggedMultiset.h
+++ b/src/construct/multiset/ConstructRaggedMultiset.h
@@ -105,8 +105,9 @@ constructRaggedMultisetCsf(const std::vector<std::string> &keys,
     shared_cb = std::make_shared<CsfCodebook<T>>(canonicalHuffman<T>(pooled));
   }
 
-  using ColumnState = typename RaggedMultisetCsf<T>::ColumnState;
-  std::vector<ColumnState> columns(max_length);
+  using Group = typename RaggedMultisetCsf<T>::Group;
+  using GroupColumn = typename MultisetCsf<T>::GroupColumn;
+  std::vector<Group> groups(max_length);
 
   for (size_t c = 0; c < max_length; c++) {
     const auto &active_keys = col_keys[c];
@@ -135,19 +136,32 @@ constructRaggedMultisetCsf(const std::vector<std::string> &keys,
     const auto &build_keys = using_filter ? filtered_keys : active_keys;
     const auto &build_values = using_filter ? filtered_values : active_values;
 
-    // Handle case where filter removed all keys
-    if (build_keys.empty()) {
-      columns[c].filter = col_filter;
-      columns[c].most_common_value = mcv;
-      columns[c].codebook = shared_cb ? shared_cb
-          : std::make_shared<CsfCodebook<T>>();
-      columns[c].buildQueryCache();
-      continue;
-    }
-
+    // Per-column codebook (or shared) + single-column group assembly.
     auto col_codebook = config.shared_codebook
         ? shared_cb
-        : std::make_shared<CsfCodebook<T>>(canonicalHuffman<T>(build_values));
+        : std::make_shared<CsfCodebook<T>>(
+              build_values.empty()
+                  ? CsfCodebook<T>{}
+                  : canonicalHuffman<T>(build_values));
+
+    Group group;
+    GroupColumn gc;
+    gc.output_index = static_cast<uint32_t>(c);
+    gc.codebook = col_codebook;
+    gc.filter = col_filter;
+    gc.most_common_value = mcv;
+    gc.uses_shared_codebook = config.shared_codebook;
+    gc.max_codelength = col_codebook ? col_codebook->max_codelength : 0;
+
+    if (build_keys.empty()) {
+      group.hash_store_seed = 0;
+      group.num_buckets = 0;
+      group.arena.num_cols = 1;
+      group.arena.num_buckets = 0;
+      group.columns.push_back(std::move(gc));
+      groups[c] = std::move(group);
+      continue;
+    }
 
     const CodeDict<T> &codedict = col_codebook->codedict;
     uint32_t max_cl = col_codebook->max_codelength;
@@ -181,16 +195,20 @@ constructRaggedMultisetCsf(const std::vector<std::string> &keys,
       std::rethrow_exception(exception);
     }
 
-    columns[c].solutions_and_seeds = std::move(solutions_and_seeds);
-    columns[c].hash_store_seed = hash_store.seed;
-    columns[c].codebook = col_codebook;
-    columns[c].filter = col_filter;
-    columns[c].most_common_value = mcv;
-    columns[c].buildQueryCache();
+    group.hash_store_seed = static_cast<uint32_t>(hash_store.seed);
+    group.num_buckets = static_cast<uint32_t>(hash_store.num_buckets);
+
+    std::vector<std::vector<SubsystemSolutionSeedPair>> per_col_solutions(1);
+    per_col_solutions[0] = std::move(solutions_and_seeds);
+    packArena<T>(group.arena, per_col_solutions,
+                 static_cast<uint32_t>(hash_store.num_buckets));
+
+    group.columns.push_back(std::move(gc));
+    groups[c] = std::move(group);
   }
 
   return std::make_shared<RaggedMultisetCsf<T>>(std::move(length_csf),
-                                                 std::move(columns));
+                                                 std::move(groups));
 }
 
 } // namespace caramel

--- a/src/construct/multiset/ConstructRaggedMultiset.h
+++ b/src/construct/multiset/ConstructRaggedMultiset.h
@@ -165,17 +165,15 @@ constructRaggedMultisetCsf(const std::vector<std::string> &keys,
     uint64_t num_buckets =
         targetBucketCount(build_values, col_codebook->codedict);
 
-    BucketedHashStore<T> hash_store =
-        partitionToBuckets<T>(build_keys, build_values, num_buckets);
-    group.hash_store_seed = static_cast<uint32_t>(hash_store.seed);
+    KeyPartition part =
+        partitionKeys(build_keys, static_cast<uint32_t>(num_buckets));
+    group.hash_store_seed = static_cast<uint32_t>(part.seed);
 
-    // One group per column (M=1): solve directly into the arena.
-    std::vector<std::vector<std::vector<T>>> value_buckets_per_col(1);
-    value_buckets_per_col[0] = std::move(hash_store.value_buckets);
+    // One group per column (M=1): stream-solve directly into the arena.
+    std::vector<std::vector<T>> source_values_per_col(1);
+    source_values_per_col[0] = std::move(build_values);
     std::vector<std::shared_ptr<CsfCodebook<T>>> codebooks{col_codebook};
-    fillArena<T>(group.arena, hash_store.key_buckets, value_buckets_per_col,
-                 codebooks, static_cast<uint32_t>(hash_store.num_buckets),
-                 DELTA);
+    fillArena<T>(group.arena, part, source_values_per_col, codebooks, DELTA);
 
     group.columns.push_back(std::move(gc));
     groups[c] = std::move(group);

--- a/src/construct/multiset/ConstructRaggedMultiset.h
+++ b/src/construct/multiset/ConstructRaggedMultiset.h
@@ -176,10 +176,17 @@ constructRaggedMultisetCsf(const std::vector<std::string> &keys,
     std::vector<std::shared_ptr<CsfCodebook<T>>> codebooks{col_codebook};
     std::vector<uint32_t> col_indices{0};
     fillArena<T>(group.arena, part, source_values_per_col, codebooks,
-                 col_indices, /*data=*/nullptr, /*num_columns=*/0, DELTA);
+                 col_indices, /*data=*/nullptr, /*num_columns=*/0,
+                 /*codebooks_disposable=*/!config.shared_codebook, DELTA);
 
     group.columns.push_back(std::move(gc));
     groups[c] = std::move(group);
+  }
+
+  // Shared codebook reused across columns; free its construction-only codedict
+  // now that every column is solved (queries never touch it).
+  if (config.shared_codebook && shared_cb) {
+    shared_cb->codedict = CodeDict<T>();
   }
 
   return std::make_shared<RaggedMultisetCsf<T>>(

--- a/src/construct/multiset/ConstructRaggedMultiset.h
+++ b/src/construct/multiset/ConstructRaggedMultiset.h
@@ -155,7 +155,6 @@ constructRaggedMultisetCsf(const std::vector<std::string> &keys,
 
     if (build_keys.empty()) {
       group.hash_store_seed = 0;
-      group.num_buckets = 0;
       group.arena.num_cols = 1;
       group.arena.num_buckets = 0;
       group.columns.push_back(std::move(gc));
@@ -163,52 +162,27 @@ constructRaggedMultisetCsf(const std::vector<std::string> &keys,
       continue;
     }
 
-    const CodeDict<T> &codedict = col_codebook->codedict;
-    uint32_t max_cl = col_codebook->max_codelength;
-
-    uint64_t num_buckets = targetBucketCount(build_values, codedict);
+    uint64_t num_buckets =
+        targetBucketCount(build_values, col_codebook->codedict);
 
     BucketedHashStore<T> hash_store =
         partitionToBuckets<T>(build_keys, build_values, num_buckets);
-
-    std::exception_ptr exception = nullptr;
-    std::vector<SubsystemSolutionSeedPair> solutions_and_seeds(
-        hash_store.num_buckets);
-
-#pragma omp parallel for default(none)                                         \
-    shared(hash_store, solutions_and_seeds, exception, codedict, max_cl, DELTA)
-    for (uint32_t j = 0; j < hash_store.num_buckets; j++) {
-      if (exception) {
-        continue;
-      }
-      try {
-        solutions_and_seeds[j] = constructAndSolveSubsystem<T>(
-            hash_store.key_buckets[j], hash_store.value_buckets[j], codedict,
-            max_cl, DELTA);
-      } catch (std::exception &) {
-#pragma omp critical
-        { exception = std::current_exception(); }
-      }
-    }
-
-    if (exception) {
-      std::rethrow_exception(exception);
-    }
-
     group.hash_store_seed = static_cast<uint32_t>(hash_store.seed);
-    group.num_buckets = static_cast<uint32_t>(hash_store.num_buckets);
 
-    std::vector<std::vector<SubsystemSolutionSeedPair>> per_col_solutions(1);
-    per_col_solutions[0] = std::move(solutions_and_seeds);
-    packArena<T>(group.arena, per_col_solutions,
-                 static_cast<uint32_t>(hash_store.num_buckets));
+    // One group per column (M=1): solve directly into the arena.
+    std::vector<std::vector<std::vector<T>>> value_buckets_per_col(1);
+    value_buckets_per_col[0] = std::move(hash_store.value_buckets);
+    std::vector<std::shared_ptr<CsfCodebook<T>>> codebooks{col_codebook};
+    fillArena<T>(group.arena, hash_store.key_buckets, value_buckets_per_col,
+                 codebooks, static_cast<uint32_t>(hash_store.num_buckets),
+                 DELTA);
 
     group.columns.push_back(std::move(gc));
     groups[c] = std::move(group);
   }
 
-  return std::make_shared<RaggedMultisetCsf<T>>(std::move(length_csf),
-                                                 std::move(groups));
+  return std::make_shared<RaggedMultisetCsf<T>>(
+      std::move(length_csf), std::move(groups), shared_cb);
 }
 
 } // namespace caramel

--- a/src/construct/multiset/ConstructRaggedMultiset.h
+++ b/src/construct/multiset/ConstructRaggedMultiset.h
@@ -169,11 +169,14 @@ constructRaggedMultisetCsf(const std::vector<std::string> &keys,
         partitionKeys(build_keys, static_cast<uint32_t>(num_buckets));
     group.hash_store_seed = static_cast<uint32_t>(part.seed);
 
-    // One group per column (M=1): stream-solve directly into the arena.
+    // One group per column (M=1): stream-solve directly into the arena. Values
+    // are provided here (no row-major buffer to re-extract from).
     std::vector<std::vector<T>> source_values_per_col(1);
     source_values_per_col[0] = std::move(build_values);
     std::vector<std::shared_ptr<CsfCodebook<T>>> codebooks{col_codebook};
-    fillArena<T>(group.arena, part, source_values_per_col, codebooks, DELTA);
+    std::vector<uint32_t> col_indices{0};
+    fillArena<T>(group.arena, part, source_values_per_col, codebooks,
+                 col_indices, /*data=*/nullptr, /*num_columns=*/0, DELTA);
 
     group.columns.push_back(std::move(gc));
     groups[c] = std::move(group);

--- a/src/construct/multiset/MultisetCsf.h
+++ b/src/construct/multiset/MultisetCsf.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "src/construct/BucketedHashStore.h"
 #include "src/construct/CsfCodebook.h"
 #include "src/construct/CsfQueryCore.h"
 #include "src/construct/Csf.h"
 #include <cereal/types/memory.hpp>
 #include <cereal/types/optional.hpp>
+#include <cereal/types/vector.hpp>
 #include <filesystem>
 
 namespace caramel {
@@ -12,61 +14,150 @@ namespace caramel {
 template <typename T> class MultisetCsf;
 template <typename T> using MultisetCsfPtr = std::shared_ptr<MultisetCsf<T>>;
 
+// E3 (interleaved-bucket-layout): columns are grouped by shared active-key set
+// (shared filter / no filter = one group, per-col filter = one group per col).
+// Each group has a single hash store (seed + num_buckets) so the hot path
+// computes signature/bucket once per group. Within a group, solution bits for
+// all M columns of the same bucket are packed contiguously in a flat arena,
+// making the per-column fan-out a sequential streaming read.
 template <typename T> class MultisetCsf {
 public:
-  struct ColumnState {
-    std::vector<SubsystemSolutionSeedPair> solutions_and_seeds;
-    uint32_t hash_store_seed = 0;
+  // Per-column metadata within a group. All bit-level data lives in the group
+  // arena; this struct only describes how to interpret the arena for col c.
+  struct GroupColumn {
+    uint32_t output_index = 0;  // index into outputs[] returned by query()
     std::shared_ptr<CsfCodebook<T>> codebook;
     PreFilterPtr<T> filter;
     std::optional<T> most_common_value;
-    // When true, the shared codebook lives in a sibling file (for
-    // directory-based save) or in the enclosing object (for single-archive
-    // save with cereal shared_ptr tracking), and must be injected before
-    // buildQueryCache() is called.
+    // When true, the shared codebook is owned by the enclosing MultisetCsf and
+    // must be injected during load before buildQueryCache().
     bool uses_shared_codebook = false;
+    // max_codelength cached for hot path (mirrors codebook->max_codelength).
+    uint32_t max_codelength = 0;
 
-    // Query caches (not serialized)
-    std::vector<BucketQueryInfo> bucket_info;
-    uint32_t num_buckets = 0;
-
-    void buildQueryCache() {
-      num_buckets = solutions_and_seeds.size();
-      bucket_info.resize(num_buckets);
-      for (uint32_t i = 0; i < num_buckets; i++) {
-        auto &[solution, seed] = solutions_and_seeds[i];
-        bucket_info[i] = {solution->backingArrayPtr(),
-                          solution->numBits() - codebook->max_codelength, seed};
-      }
-    }
-
-  private:
+   private:
     friend class cereal::access;
-
     template <class Archive> void save(Archive &archive) const {
-      archive(solutions_and_seeds, hash_store_seed, filter, most_common_value,
-              uses_shared_codebook);
+      archive(output_index, filter, most_common_value, uses_shared_codebook,
+              max_codelength);
       if (!uses_shared_codebook) {
         archive(codebook);
       }
     }
-
     template <class Archive> void load(Archive &archive) {
-      archive(solutions_and_seeds, hash_store_seed, filter, most_common_value,
-              uses_shared_codebook);
+      archive(output_index, filter, most_common_value, uses_shared_codebook,
+              max_codelength);
       if (!uses_shared_codebook) {
         archive(codebook);
       }
-      // Deferred: buildQueryCache() must be called by the enclosing load path
-      // after the codebook is assigned (may be injected externally for the
-      // shared-codebook case).
     }
   };
 
-  MultisetCsf(std::vector<ColumnState> columns,
+  // Flat bucket-contiguous arena:
+  //   - solution_bits: concatenation of all per-(bucket, col) bit ranges.
+  //   - bucket_offsets[b]: start bit position in solution_bits for bucket b's
+  //     block. bucket_offsets has size num_buckets+1 (last = total bits).
+  //   - per_col_bits[b*M + c]: length in bits of column c's sub-range in
+  //     bucket b. Column c's bits live at:
+  //       start = bucket_offsets[b] + sum_{c'<c} per_col_bits[b*M + c']
+  //       end   = start + per_col_bits[b*M + c]
+  //   - per_col_seeds[b*M + c]: subsystem solve seed for (b, c).
+  // Layout guarantees: for a single bucket b, columns 0..M-1 are stored
+  // contiguously, so the inner query loop streams through the bucket block.
+  struct BucketArena {
+    std::vector<uint64_t> solution_bits;
+    std::vector<uint64_t> bucket_offsets;
+    std::vector<uint32_t> per_col_bits;
+    std::vector<uint32_t> per_col_seeds;
+    uint32_t num_cols = 0;
+    uint32_t num_buckets = 0;
+
+   private:
+    friend class cereal::access;
+    template <class Archive> void serialize(Archive &archive) {
+      archive(solution_bits, bucket_offsets, per_col_bits, per_col_seeds,
+              num_cols, num_buckets);
+    }
+  };
+
+  // A group of columns that share a single hash store and arena. Columns end
+  // up in the same group iff their active-key sets are identical (shared
+  // filter, or no filter at all).
+  struct Group {
+    uint32_t hash_store_seed = 0;
+    uint32_t num_buckets = 0;
+    BucketArena arena;
+    std::vector<GroupColumn> columns;
+
+    // Query caches: flat array of BucketQueryInfo laid out as
+    // [bucket 0 col 0, bucket 0 col 1, ..., bucket 0 col M-1,
+    //  bucket 1 col 0, ...]. Same interleaved layout as the arena itself.
+    // Not serialized.
+    std::vector<BucketQueryInfo> bucket_col_info;
+
+    void buildQueryCache() {
+      const uint32_t M = arena.num_cols;
+      const uint32_t B = arena.num_buckets;
+      bucket_col_info.assign(static_cast<size_t>(M) * B, BucketQueryInfo{});
+
+      const uint64_t *backing = arena.solution_bits.data();
+      // For each (bucket, col), the effective "data pointer" is the backing
+      // array offset to the start of that range, rounded down to 64-bit word.
+      // But we need bit-level indexing; we store word-aligned arr + a bit
+      // offset. To keep BucketQueryInfo unchanged, we wrap using a helper:
+      // for (b, c), the solution bits start at absolute bit position
+      //   start_bit = bucket_offsets[b] + prefix_sum(per_col_bits[b*M..b*M+c])
+      // num_variables = per_col_bits[b*M + c] - col_max_codelength.
+      //
+      // queryCsfCore wants a uint64_t* that lets it read bits with an
+      // absolute bit offset equal to the range start. The existing code uses
+      // `arr[word]` with `pos / 64` and `pos % 64`. We pass a pointer to the
+      // word containing the start, but only if the range starts at a word
+      // boundary. To avoid adding bit-shifting fixup to the hot path, we
+      // require start_bit % 64 == 0 (enforced by padding during build).
+      for (uint32_t b = 0; b < B; b++) {
+        uint64_t bit_off = arena.bucket_offsets[b];
+        for (uint32_t c = 0; c < M; c++) {
+          uint32_t len_bits = arena.per_col_bits[b * M + c];
+          uint32_t seed = arena.per_col_seeds[b * M + c];
+          uint32_t max_cl = columns[c].max_codelength;
+          uint64_t word = bit_off / 64;
+          bucket_col_info[b * M + c] = BucketQueryInfo{
+              backing + word,
+              static_cast<uint32_t>(len_bits - max_cl),
+              seed};
+          // Advance to the next word-aligned boundary — each (bucket, col)
+          // range is padded up to 64 bits so query reads are word-indexed.
+          bit_off += (len_bits + 63u) & ~static_cast<uint64_t>(63u);
+        }
+      }
+    }
+
+   private:
+    friend class cereal::access;
+    template <class Archive> void save(Archive &archive) const {
+      archive(hash_store_seed, num_buckets, arena, columns);
+    }
+    template <class Archive> void load(Archive &archive) {
+      archive(hash_store_seed, num_buckets, arena, columns);
+    }
+  };
+
+  MultisetCsf(std::vector<Group> groups, uint32_t total_cols,
               std::shared_ptr<CsfCodebook<T>> shared_codebook = nullptr)
-      : _columns(std::move(columns)),
-        _shared_codebook(std::move(shared_codebook)) {}
+      : _groups(std::move(groups)), _total_cols(total_cols),
+        _shared_codebook(std::move(shared_codebook)) {
+    for (auto &g : _groups) {
+      if (_shared_codebook) {
+        for (auto &col : g.columns) {
+          if (col.uses_shared_codebook) {
+            col.codebook = _shared_codebook;
+          }
+        }
+      }
+      g.buildQueryCache();
+    }
+  }
 
   std::vector<T> query(const std::string &key, bool parallelize = true) const {
     return query(key.data(), key.size(), parallelize);
@@ -74,86 +165,84 @@ public:
 
   std::vector<T> query(const char *data, size_t length,
                        bool parallelize = true) const {
-    std::vector<T> outputs(_columns.size());
+    std::vector<T> outputs(_total_cols);
 
 #pragma omp parallel for default(none)                                         \
-    shared(data, length, _columns, outputs) if (parallelize)
-    for (size_t i = 0; i < _columns.size(); i++) {
-      const auto &col = _columns[i];
-      if (col.filter && !col.filter->contains(data, length)) {
-        outputs[i] = *col.most_common_value;
-      } else if (col.bucket_info.empty()) {
-        outputs[i] = *col.most_common_value;
-      } else {
-        outputs[i] = queryCsfCore<T>(data, length, col.hash_store_seed,
-                                     col.bucket_info, col.num_buckets,
-                                     col.codebook->max_codelength,
-                                     col.codebook->code_length_counts,
-                                     col.codebook->ordered_symbols);
+    shared(data, length, _groups, outputs) if (parallelize)
+    for (size_t gi = 0; gi < _groups.size(); gi++) {
+      const auto &group = _groups[gi];
+      // Group-level hash: compute signature + bucket_id once for the whole
+      // group. This is the E2/E3 payoff — per-column query no longer rehashes.
+      __uint128_t signature = hashKey(data, length, group.hash_store_seed);
+      uint32_t bucket_id = group.num_buckets
+                               ? getBucketID(signature, group.num_buckets)
+                               : 0;
+      const uint32_t M = group.arena.num_cols;
+
+      for (size_t ci = 0; ci < group.columns.size(); ci++) {
+        const auto &col = group.columns[ci];
+        T value;
+        if (col.filter && !col.filter->contains(data, length)) {
+          value = *col.most_common_value;
+        } else if (group.num_buckets == 0) {
+          value = *col.most_common_value;
+        } else {
+          const auto &info = group.bucket_col_info[bucket_id * M + ci];
+          uint64_t e[3];
+          signatureToEquation(signature, info.seed, info.num_variables, e);
+
+          const uint64_t *arr = info.data;
+          const int l = 64 - static_cast<int>(col.max_codelength);
+          auto getbits = [arr, l](uint32_t pos)
+                             __attribute__((always_inline)) {
+            const uint64_t w = pos / 64;
+            const int b = pos % 64;
+            if (b <= l)
+              return arr[w] << b >> l;
+            return arr[w] << b >> l | arr[w + 1] >> (128 - (-l + 64) - b);
+          };
+          uint64_t encoded =
+              getbits(e[0]) ^ getbits(e[1]) ^ getbits(e[2]);
+          value = canonicalDecodeFromNumber<T>(
+              encoded, col.codebook->code_length_counts,
+              col.codebook->ordered_symbols, col.max_codelength);
+        }
+        outputs[col.output_index] = value;
       }
     }
 
     return outputs;
   }
 
-  static void saveColumnState(const ColumnState &col, const std::string &path) {
-    auto stream = SafeFileIO::ofstream(path, std::ios::binary);
-    cereal::BinaryOutputArchive archive(stream);
-    archive(col);
-  }
-
-  // Loads a column and runs buildQueryCache(). Only valid if the column does
-  // not use a shared codebook (otherwise the codebook must be injected first).
-  static ColumnState loadColumnState(const std::string &path) {
-    auto stream = SafeFileIO::ifstream(path, std::ios::binary);
-    cereal::BinaryInputArchive archive(stream);
-    ColumnState col;
-    archive(col);
-    if (!col.uses_shared_codebook) {
-      col.buildQueryCache();
-    }
-    return col;
-  }
-
-  static void saveSharedCodebook(const CsfCodebook<T> &cb,
-                                 const std::string &path) {
-    auto stream = SafeFileIO::ofstream(path, std::ios::binary);
-    cereal::BinaryOutputArchive archive(stream);
-    archive(cb);
-  }
-
-  static std::shared_ptr<CsfCodebook<T>>
-  loadSharedCodebook(const std::string &path) {
-    auto stream = SafeFileIO::ifstream(path, std::ios::binary);
-    cereal::BinaryInputArchive archive(stream);
-    auto cb = std::make_shared<CsfCodebook<T>>();
-    archive(*cb);
-    return cb;
-  }
-
   void save(const std::string &path, const uint32_t type_id = 0) const {
     std::filesystem::create_directories(path);
     {
       auto meta = SafeFileIO::ofstream(path + "/metadata.bin", std::ios::binary);
-      uint32_t num_cols = _columns.size();
+      uint32_t num_groups = _groups.size();
       uint8_t uses_shared = _shared_codebook ? 1 : 0;
       meta.write(reinterpret_cast<const char *>(&type_id), sizeof(uint32_t));
-      meta.write(reinterpret_cast<const char *>(&num_cols), sizeof(uint32_t));
+      meta.write(reinterpret_cast<const char *>(&_total_cols), sizeof(uint32_t));
+      meta.write(reinterpret_cast<const char *>(&num_groups), sizeof(uint32_t));
       meta.write(reinterpret_cast<const char *>(&uses_shared), sizeof(uint8_t));
     }
     if (_shared_codebook) {
-      saveSharedCodebook(*_shared_codebook, path + "/shared_codebook.bin");
+      auto stream =
+          SafeFileIO::ofstream(path + "/shared_codebook.bin", std::ios::binary);
+      cereal::BinaryOutputArchive archive(stream);
+      archive(*_shared_codebook);
     }
-    for (size_t i = 0; i < _columns.size(); i++) {
-      saveColumnState(_columns[i],
-                      path + "/col_" + std::to_string(i) + ".bin");
+    for (size_t i = 0; i < _groups.size(); i++) {
+      auto stream = SafeFileIO::ofstream(
+          path + "/group_" + std::to_string(i) + ".bin", std::ios::binary);
+      cereal::BinaryOutputArchive archive(stream);
+      archive(_groups[i]);
     }
   }
 
   static MultisetCsfPtr<T> load(const std::string &path,
                                 const uint32_t type_id = 0) {
     auto meta = SafeFileIO::ifstream(path + "/metadata.bin", std::ios::binary);
-    uint32_t type_id_found = 0, num_cols = 0;
+    uint32_t type_id_found = 0, total_cols = 0, num_groups = 0;
     uint8_t uses_shared = 0;
     meta.read(reinterpret_cast<char *>(&type_id_found), sizeof(uint32_t));
     if (type_id != type_id_found) {
@@ -162,30 +251,43 @@ public:
           " but found type_id = " + std::to_string(type_id_found) +
           " when deserializing " + path);
     }
-    meta.read(reinterpret_cast<char *>(&num_cols), sizeof(uint32_t));
+    meta.read(reinterpret_cast<char *>(&total_cols), sizeof(uint32_t));
+    meta.read(reinterpret_cast<char *>(&num_groups), sizeof(uint32_t));
     meta.read(reinterpret_cast<char *>(&uses_shared), sizeof(uint8_t));
 
     std::shared_ptr<CsfCodebook<T>> shared_cb;
     if (uses_shared) {
-      shared_cb = loadSharedCodebook(path + "/shared_codebook.bin");
+      auto stream =
+          SafeFileIO::ifstream(path + "/shared_codebook.bin", std::ios::binary);
+      cereal::BinaryInputArchive archive(stream);
+      shared_cb = std::make_shared<CsfCodebook<T>>();
+      archive(*shared_cb);
     }
 
-    std::vector<ColumnState> columns(num_cols);
-    for (uint32_t i = 0; i < num_cols; i++) {
-      columns[i] =
-          loadColumnState(path + "/col_" + std::to_string(i) + ".bin");
-      if (columns[i].uses_shared_codebook) {
-        columns[i].codebook = shared_cb;
-        columns[i].buildQueryCache();
-      }
+    std::vector<Group> groups(num_groups);
+    for (uint32_t i = 0; i < num_groups; i++) {
+      auto stream = SafeFileIO::ifstream(
+          path + "/group_" + std::to_string(i) + ".bin", std::ios::binary);
+      cereal::BinaryInputArchive archive(stream);
+      archive(groups[i]);
     }
-    return std::make_shared<MultisetCsf<T>>(std::move(columns), shared_cb);
+
+    return std::make_shared<MultisetCsf<T>>(std::move(groups), total_cols,
+                                             shared_cb);
+  }
+
+  // Accessors (used by RaggedMultisetCsf and tests)
+  const std::vector<Group> &groups() const { return _groups; }
+  uint32_t totalCols() const { return _total_cols; }
+  std::shared_ptr<CsfCodebook<T>> sharedCodebook() const {
+    return _shared_codebook;
   }
 
 private:
   MultisetCsf() {}
 
-  std::vector<ColumnState> _columns;
+  std::vector<Group> _groups;
+  uint32_t _total_cols = 0;
   std::shared_ptr<CsfCodebook<T>> _shared_codebook;
 };
 

--- a/src/construct/multiset/MultisetCsf.h
+++ b/src/construct/multiset/MultisetCsf.h
@@ -53,29 +53,27 @@ public:
     }
   };
 
-  // Flat bucket-contiguous arena:
-  //   - solution_bits: concatenation of all per-(bucket, col) bit ranges.
-  //   - bucket_offsets[b]: start bit position in solution_bits for bucket b's
-  //     block. bucket_offsets has size num_buckets+1 (last = total bits).
-  //   - per_col_bits[b*M + c]: length in bits of column c's sub-range in
-  //     bucket b. Column c's bits live at:
-  //       start = bucket_offsets[b] + sum_{c'<c} per_col_bits[b*M + c']
-  //       end   = start + per_col_bits[b*M + c]
-  //   - per_col_seeds[b*M + c]: subsystem solve seed for (b, c).
-  // Layout guarantees: for a single bucket b, columns 0..M-1 are stored
-  // contiguously, so the inner query loop streams through the bucket block.
+  // Flat bucket-contiguous arena. solution_bits concatenates every
+  // per-(bucket, col) bit range, bucket-major (all M columns of bucket 0, then
+  // bucket 1, ...) so one bucket's columns stream contiguously at query time.
+  // per_col_word_off[b*M + c] is the word offset of that range's start (each
+  // range word-aligned); per_col_bits its bit length; per_col_seeds its solve
+  // seed.
   struct BucketArena {
     std::vector<uint64_t> solution_bits;
-    std::vector<uint64_t> bucket_offsets;
     std::vector<uint32_t> per_col_bits;
     std::vector<uint32_t> per_col_seeds;
+    // Word index into solution_bits where (bucket b, col c)'s range starts.
+    // Computed once by fillArena (the authoritative offset walk) so the query
+    // cache never recomputes the padding arithmetic.
+    std::vector<uint64_t> per_col_word_off;
     uint32_t num_cols = 0;
     uint32_t num_buckets = 0;
 
    private:
     friend class cereal::access;
     template <class Archive> void serialize(Archive &archive) {
-      archive(solution_bits, bucket_offsets, per_col_bits, per_col_seeds,
+      archive(solution_bits, per_col_bits, per_col_seeds, per_col_word_off,
               num_cols, num_buckets);
     }
   };
@@ -85,9 +83,10 @@ public:
   // filter, or no filter at all).
   struct Group {
     uint32_t hash_store_seed = 0;
-    uint32_t num_buckets = 0;
     BucketArena arena;
     std::vector<GroupColumn> columns;
+
+    uint32_t num_buckets() const { return arena.num_buckets; }
 
     // Query caches: flat array of BucketQueryInfo laid out as
     // [bucket 0 col 0, bucket 0 col 1, ..., bucket 0 col M-1,
@@ -101,45 +100,50 @@ public:
       bucket_col_info.assign(static_cast<size_t>(M) * B, BucketQueryInfo{});
 
       const uint64_t *backing = arena.solution_bits.data();
-      // For each (bucket, col), the effective "data pointer" is the backing
-      // array offset to the start of that range, rounded down to 64-bit word.
-      // But we need bit-level indexing; we store word-aligned arr + a bit
-      // offset. To keep BucketQueryInfo unchanged, we wrap using a helper:
-      // for (b, c), the solution bits start at absolute bit position
-      //   start_bit = bucket_offsets[b] + prefix_sum(per_col_bits[b*M..b*M+c])
-      // num_variables = per_col_bits[b*M + c] - col_max_codelength.
-      //
-      // queryCsfCore wants a uint64_t* that lets it read bits with an
-      // absolute bit offset equal to the range start. The existing code uses
-      // `arr[word]` with `pos / 64` and `pos % 64`. We pass a pointer to the
-      // word containing the start, but only if the range starts at a word
-      // boundary. To avoid adding bit-shifting fixup to the hot path, we
-      // require start_bit % 64 == 0 (enforced by padding during build).
+      // Each range starts on a 64-bit word boundary (padded by fillArena), so
+      // the query "data pointer" is just backing + the precomputed word offset.
       for (uint32_t b = 0; b < B; b++) {
-        uint64_t bit_off = arena.bucket_offsets[b];
         for (uint32_t c = 0; c < M; c++) {
-          uint32_t len_bits = arena.per_col_bits[b * M + c];
-          uint32_t seed = arena.per_col_seeds[b * M + c];
-          uint32_t max_cl = columns[c].max_codelength;
-          uint64_t word = bit_off / 64;
-          bucket_col_info[b * M + c] = BucketQueryInfo{
-              backing + word,
-              static_cast<uint32_t>(len_bits - max_cl),
-              seed};
-          // Advance to the next word-aligned boundary — each (bucket, col)
-          // range is padded up to 64 bits so query reads are word-indexed.
-          bit_off += (len_bits + 63u) & ~static_cast<uint64_t>(63u);
+          size_t idx = static_cast<size_t>(b) * M + c;
+          uint32_t num_vars = arena.per_col_bits[idx] - columns[c].max_codelength;
+          bucket_col_info[idx] = BucketQueryInfo{
+              backing + arena.per_col_word_off[idx], num_vars,
+              arena.per_col_seeds[idx]};
         }
       }
     }
 
+    // Decodes column ci of this group for one key. signature/bucket_id are the
+    // group-level hash results (computed once per group by the caller). Shared
+    // by MultisetCsf::query and RaggedMultisetCsf::query.
+    T queryColumn(size_t ci, const char *data, size_t length,
+                  const __uint128_t &signature, uint32_t bucket_id) const {
+      const auto &col = columns[ci];
+      // A no-filter column has no most-common value; an empty/degenerate group
+      // then has nothing to return, so fall back to T{}.
+      if (col.filter && !col.filter->contains(data, length)) {
+        return col.most_common_value.value_or(T{});
+      }
+      if (arena.num_buckets == 0) {
+        return col.most_common_value.value_or(T{});
+      }
+      const uint32_t M = arena.num_cols;
+      const auto &info = bucket_col_info[bucket_id * M + ci];
+      // Defensive: a column with no codebook (degenerate / unset) has nothing
+      // to decode, so fall back to the most-common value instead of a null
+      // dereference in the decode tail.
+      if (!col.codebook) {
+        return col.most_common_value.value_or(T{});
+      }
+      return decodeBucketColumn<T>(signature, info, col.max_codelength,
+                                   col.codebook->code_length_counts,
+                                   col.codebook->ordered_symbols);
+    }
+
    private:
     friend class cereal::access;
-    template <class Archive> void save(Archive &archive) const {
-      archive(hash_store_seed, num_buckets, arena, columns);
-    }
-    template <class Archive> void load(Archive &archive) {
-      archive(hash_store_seed, num_buckets, arena, columns);
+    template <class Archive> void serialize(Archive &archive) {
+      archive(hash_store_seed, arena, columns);
     }
   };
 
@@ -174,40 +178,13 @@ public:
       // Group-level hash: compute signature + bucket_id once for the whole
       // group. This is the E2/E3 payoff — per-column query no longer rehashes.
       __uint128_t signature = hashKey(data, length, group.hash_store_seed);
-      uint32_t bucket_id = group.num_buckets
-                               ? getBucketID(signature, group.num_buckets)
+      uint32_t bucket_id = group.num_buckets()
+                               ? getBucketID(signature, group.num_buckets())
                                : 0;
-      const uint32_t M = group.arena.num_cols;
 
       for (size_t ci = 0; ci < group.columns.size(); ci++) {
-        const auto &col = group.columns[ci];
-        T value;
-        if (col.filter && !col.filter->contains(data, length)) {
-          value = *col.most_common_value;
-        } else if (group.num_buckets == 0) {
-          value = *col.most_common_value;
-        } else {
-          const auto &info = group.bucket_col_info[bucket_id * M + ci];
-          uint64_t e[3];
-          signatureToEquation(signature, info.seed, info.num_variables, e);
-
-          const uint64_t *arr = info.data;
-          const int l = 64 - static_cast<int>(col.max_codelength);
-          auto getbits = [arr, l](uint32_t pos)
-                             __attribute__((always_inline)) {
-            const uint64_t w = pos / 64;
-            const int b = pos % 64;
-            if (b <= l)
-              return arr[w] << b >> l;
-            return arr[w] << b >> l | arr[w + 1] >> (128 - (-l + 64) - b);
-          };
-          uint64_t encoded =
-              getbits(e[0]) ^ getbits(e[1]) ^ getbits(e[2]);
-          value = canonicalDecodeFromNumber<T>(
-              encoded, col.codebook->code_length_counts,
-              col.codebook->ordered_symbols, col.max_codelength);
-        }
-        outputs[col.output_index] = value;
+        outputs[group.columns[ci].output_index] =
+            group.queryColumn(ci, data, length, signature, bucket_id);
       }
     }
 

--- a/src/construct/multiset/RaggedMultisetCsf.h
+++ b/src/construct/multiset/RaggedMultisetCsf.h
@@ -9,14 +9,19 @@ template <typename T> class RaggedMultisetCsf;
 template <typename T>
 using RaggedMultisetCsfPtr = std::shared_ptr<RaggedMultisetCsf<T>>;
 
+// Ragged multiset: one Group per column (key sets differ per column because
+// of variable row lengths, so hash-store sharing across columns is not
+// applicable). Still benefits from the flat arena layout per column.
 template <typename T> class RaggedMultisetCsf {
 public:
-  using ColumnState = typename MultisetCsf<T>::ColumnState;
+  using Group = typename MultisetCsf<T>::Group;
 
-  RaggedMultisetCsf(CsfPtr<uint32_t> length_csf,
-                    std::vector<ColumnState> columns)
-      : _length_csf(std::move(length_csf)),
-        _columns(std::move(columns)) {}
+  RaggedMultisetCsf(CsfPtr<uint32_t> length_csf, std::vector<Group> groups)
+      : _length_csf(std::move(length_csf)), _groups(std::move(groups)) {
+    for (auto &g : _groups) {
+      g.buildQueryCache();
+    }
+  }
 
   std::vector<T> query(const std::string &key) const {
     return query(key.data(), key.size());
@@ -24,22 +29,38 @@ public:
 
   std::vector<T> query(const char *data, size_t length) const {
     uint32_t num_values = _length_csf->query(data, length);
-    num_values = std::min(num_values, static_cast<uint32_t>(_columns.size()));
+    num_values = std::min(num_values, static_cast<uint32_t>(_groups.size()));
 
     std::vector<T> outputs(num_values);
 
     for (size_t i = 0; i < num_values; i++) {
-      const auto &col = _columns[i];
+      const auto &group = _groups[i];
+      const auto &col = group.columns[0];
       if (col.filter && !col.filter->contains(data, length)) {
         outputs[i] = *col.most_common_value;
-      } else if (col.bucket_info.empty()) {
+      } else if (group.num_buckets == 0) {
         outputs[i] = *col.most_common_value;
       } else {
-        outputs[i] = queryCsfCore<T>(data, length, col.hash_store_seed,
-                                     col.bucket_info, col.num_buckets,
-                                     col.codebook->max_codelength,
-                                     col.codebook->code_length_counts,
-                                     col.codebook->ordered_symbols);
+        __uint128_t signature = hashKey(data, length, group.hash_store_seed);
+        uint32_t bucket_id = getBucketID(signature, group.num_buckets);
+        const auto &info = group.bucket_col_info[bucket_id];
+
+        uint64_t e[3];
+        signatureToEquation(signature, info.seed, info.num_variables, e);
+
+        const uint64_t *arr = info.data;
+        const int l = 64 - static_cast<int>(col.max_codelength);
+        auto getbits = [arr, l](uint32_t pos) __attribute__((always_inline)) {
+          const uint64_t w = pos / 64;
+          const int b = pos % 64;
+          if (b <= l)
+            return arr[w] << b >> l;
+          return arr[w] << b >> l | arr[w + 1] >> (128 - (-l + 64) - b);
+        };
+        uint64_t encoded = getbits(e[0]) ^ getbits(e[1]) ^ getbits(e[2]);
+        outputs[i] = canonicalDecodeFromNumber<T>(
+            encoded, col.codebook->code_length_counts,
+            col.codebook->ordered_symbols, col.max_codelength);
       }
     }
 
@@ -77,25 +98,21 @@ private:
 
   friend class cereal::access;
   template <class Archive> void save(Archive &archive) const {
-    archive(_length_csf, _columns);
+    archive(_length_csf, _groups);
   }
 
   template <class Archive> void load(Archive &archive) {
-    archive(_length_csf, _columns);
-    // buildQueryCache was moved out of ColumnState's cereal hook to support
-    // the shared-codebook pattern (where codebook is injected externally).
-    // Ragged serializes everything in one archive, so cereal's shared_ptr
-    // tracking already dedupes the shared codebook — we just need to rebuild
-    // query caches here.
-    for (auto &col : _columns) {
-      if (col.codebook) {
-        col.buildQueryCache();
-      }
+    archive(_length_csf, _groups);
+    // Codebooks are serialized inside each group's columns (Ragged does not
+    // use a shared codebook across the MultisetCsf); cereal's shared_ptr
+    // tracking already dedupes per-column codebooks where applicable.
+    for (auto &g : _groups) {
+      g.buildQueryCache();
     }
   }
 
   CsfPtr<uint32_t> _length_csf;
-  std::vector<ColumnState> _columns;
+  std::vector<Group> _groups;
 };
 
 } // namespace caramel

--- a/src/construct/multiset/RaggedMultisetCsf.h
+++ b/src/construct/multiset/RaggedMultisetCsf.h
@@ -16,11 +16,11 @@ template <typename T> class RaggedMultisetCsf {
 public:
   using Group = typename MultisetCsf<T>::Group;
 
-  RaggedMultisetCsf(CsfPtr<uint32_t> length_csf, std::vector<Group> groups)
-      : _length_csf(std::move(length_csf)), _groups(std::move(groups)) {
-    for (auto &g : _groups) {
-      g.buildQueryCache();
-    }
+  RaggedMultisetCsf(CsfPtr<uint32_t> length_csf, std::vector<Group> groups,
+                    std::shared_ptr<CsfCodebook<T>> shared_codebook = nullptr)
+      : _length_csf(std::move(length_csf)), _groups(std::move(groups)),
+        _shared_codebook(std::move(shared_codebook)) {
+    injectSharedCodebookAndBuildCaches();
   }
 
   std::vector<T> query(const std::string &key) const {
@@ -35,33 +35,11 @@ public:
 
     for (size_t i = 0; i < num_values; i++) {
       const auto &group = _groups[i];
-      const auto &col = group.columns[0];
-      if (col.filter && !col.filter->contains(data, length)) {
-        outputs[i] = *col.most_common_value;
-      } else if (group.num_buckets == 0) {
-        outputs[i] = *col.most_common_value;
-      } else {
-        __uint128_t signature = hashKey(data, length, group.hash_store_seed);
-        uint32_t bucket_id = getBucketID(signature, group.num_buckets);
-        const auto &info = group.bucket_col_info[bucket_id];
-
-        uint64_t e[3];
-        signatureToEquation(signature, info.seed, info.num_variables, e);
-
-        const uint64_t *arr = info.data;
-        const int l = 64 - static_cast<int>(col.max_codelength);
-        auto getbits = [arr, l](uint32_t pos) __attribute__((always_inline)) {
-          const uint64_t w = pos / 64;
-          const int b = pos % 64;
-          if (b <= l)
-            return arr[w] << b >> l;
-          return arr[w] << b >> l | arr[w + 1] >> (128 - (-l + 64) - b);
-        };
-        uint64_t encoded = getbits(e[0]) ^ getbits(e[1]) ^ getbits(e[2]);
-        outputs[i] = canonicalDecodeFromNumber<T>(
-            encoded, col.codebook->code_length_counts,
-            col.codebook->ordered_symbols, col.max_codelength);
-      }
+      __uint128_t signature = hashKey(data, length, group.hash_store_seed);
+      uint32_t bucket_id = group.num_buckets()
+                               ? getBucketID(signature, group.num_buckets())
+                               : 0;
+      outputs[i] = group.queryColumn(0, data, length, signature, bucket_id);
     }
 
     return outputs;
@@ -96,23 +74,48 @@ public:
 private:
   RaggedMultisetCsf() {}
 
-  friend class cereal::access;
-  template <class Archive> void save(Archive &archive) const {
-    archive(_length_csf, _groups);
-  }
-
-  template <class Archive> void load(Archive &archive) {
-    archive(_length_csf, _groups);
-    // Codebooks are serialized inside each group's columns (Ragged does not
-    // use a shared codebook across the MultisetCsf); cereal's shared_ptr
-    // tracking already dedupes per-column codebooks where applicable.
+  // Inject the shared codebook into the columns that use it (their codebook
+  // ptr is null after load), then build the per-group query caches.
+  void injectSharedCodebookAndBuildCaches() {
     for (auto &g : _groups) {
+      if (_shared_codebook) {
+        for (auto &col : g.columns) {
+          if (col.uses_shared_codebook) {
+            col.codebook = _shared_codebook;
+          }
+        }
+      }
       g.buildQueryCache();
     }
   }
 
+  friend class cereal::access;
+  template <class Archive> void save(Archive &archive) const {
+    archive(_length_csf, _groups);
+    // Serialize the shared codebook by value behind a presence flag, rather
+    // than as a shared_ptr, to avoid cereal aliasing it with the same-typed
+    // codebook inside _length_csf.
+    bool has_shared = _shared_codebook != nullptr;
+    archive(has_shared);
+    if (has_shared) {
+      archive(*_shared_codebook);
+    }
+  }
+
+  template <class Archive> void load(Archive &archive) {
+    archive(_length_csf, _groups);
+    bool has_shared = false;
+    archive(has_shared);
+    if (has_shared) {
+      _shared_codebook = std::make_shared<CsfCodebook<T>>();
+      archive(*_shared_codebook);
+    }
+    injectSharedCodebookAndBuildCaches();
+  }
+
   CsfPtr<uint32_t> _length_csf;
   std::vector<Group> _groups;
+  std::shared_ptr<CsfCodebook<T>> _shared_codebook;
 };
 
 } // namespace caramel

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ include(GoogleTest)
 
 set(CARAMEL_TESTS
     AutoFilterSelectionTest
+    ConstructMultisetTest
     BitArrayTest
     BucketedHashStoreTest
     CodecTest

--- a/tests/ConstructMultisetTest.cc
+++ b/tests/ConstructMultisetTest.cc
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <src/construct/multiset/ConstructMultiset.h>
+#include <src/construct/multiset/MultisetConfig.h>
+
+namespace caramel::tests {
+
+namespace {
+
+std::vector<std::string> makeKeys(size_t n) {
+  std::vector<std::string> keys;
+  keys.reserve(n);
+  for (size_t i = 0; i < n; i++) {
+    keys.push_back("key_" + std::to_string(i));
+  }
+  return keys;
+}
+
+// Asserts the structural invariants fillArena() promises for one group's arena,
+// independent of any query path:
+//   - ranges are packed bucket-major, contiguous, in whole words.
+//   - per_col_word_off matches the documented offset walk exactly.
+//   - solution_bits has a trailing guard word so the decode's arr[w+1] read is
+//     always in-bounds.
+template <typename T>
+void checkArenaInvariants(const typename MultisetCsf<T>::Group &group) {
+  const auto &arena = group.arena;
+  const uint32_t M = arena.num_cols;
+  const uint32_t B = arena.num_buckets;
+
+  if (B == 0) {
+    return;  // degenerate group: no arena content to validate.
+  }
+
+  ASSERT_EQ(arena.per_col_bits.size(), static_cast<size_t>(B) * M);
+  ASSERT_EQ(arena.per_col_seeds.size(), static_cast<size_t>(B) * M);
+  ASSERT_EQ(arena.per_col_word_off.size(), static_cast<size_t>(B) * M);
+
+  uint64_t cursor_words = 0;
+  for (uint32_t b = 0; b < B; b++) {
+    for (uint32_t c = 0; c < M; c++) {
+      size_t idx = static_cast<size_t>(b) * M + c;
+      ASSERT_EQ(arena.per_col_word_off[idx], cursor_words)
+          << "per_col_word_off mismatch at (b=" << b << ",c=" << c << ")";
+      cursor_words += (arena.per_col_bits[idx] + 63u) / 64u;
+    }
+  }
+
+  ASSERT_EQ(arena.solution_bits.size(), cursor_words + 1)
+      << "missing trailing guard word";
+}
+
+// Builds a MultisetCsf from column-major values, checks the arena invariants on
+// every group, and verifies every key round-trips to its row.
+template <typename T>
+void buildCheckQuery(const std::vector<std::vector<T>> &columns) {
+  const size_t num_rows = columns.empty() ? 0 : columns[0].size();
+  auto keys = makeKeys(num_rows);
+  MultisetConfig config;
+  config.verbose = false;
+  auto csf = constructMultisetCsf<T>(keys, columns, config);
+
+  for (const auto &group : csf->groups()) {
+    checkArenaInvariants<T>(group);
+  }
+
+  for (size_t r = 0; r < num_rows; r++) {
+    std::vector<T> expected;
+    expected.reserve(columns.size());
+    for (const auto &col : columns) {
+      expected.push_back(col[r]);
+    }
+    EXPECT_EQ(csf->query(keys[r]), expected) << "row " << r;
+  }
+}
+
+}  // namespace
+
+// One no-filter group: every column shares the full key set, so all columns
+// pack into one interleaved arena and query must round-trip through the decode.
+TEST(ConstructMultisetTest, InterleavedArenaQueriesDecodeCorrectly) {
+  const size_t num_rows = 500, num_cols = 6;
+  std::vector<std::vector<uint32_t>> columns(num_cols,
+                                             std::vector<uint32_t>(num_rows));
+  for (size_t c = 0; c < num_cols; c++) {
+    for (size_t r = 0; r < num_rows; r++) {
+      columns[c][r] = static_cast<uint32_t>((r * 7 + c * 13) % 50);
+    }
+  }
+  buildCheckQuery<uint32_t>(columns);
+}
+
+// Columns with very different per-column target bucket counts (constant /
+// low-entropy / all-distinct) exercise subgrouping by bucket count; the arena
+// invariants and round-trip must hold across the resulting groups.
+TEST(ConstructMultisetTest, HeterogeneousBucketCountsRoundTrip) {
+  const size_t num_rows = 800;
+  std::vector<std::vector<uint32_t>> columns(3, std::vector<uint32_t>(num_rows));
+  for (size_t r = 0; r < num_rows; r++) {
+    columns[0][r] = 5;                              // constant
+    columns[1][r] = static_cast<uint32_t>(r % 4);   // low entropy
+    columns[2][r] = static_cast<uint32_t>(r);       // all distinct
+  }
+  buildCheckQuery<uint32_t>(columns);
+}
+
+}  // namespace caramel::tests


### PR DESCRIPTION
## Summary

Replaces the per-column `vector<BitArrayPtr>` layout in `MultisetCsf` with a per-group flat arena where bucket B's solution bits for all M columns are contiguous in memory. Combined with a shared hash store per filter-group, this turns the per-column query fan-out into streaming reads.

Measured on `movielens_1m_m100.npy` (1M rows × 100 cols, global_sort permutation, no shared codebook):

| | baseline | this PR | delta |
|---|---|---|---|
| Query latency (median) | 13,305 ns | **5,367 ns** | **-59.7%** |
| Serialized size | 111.76 MB | 110.09 MB | -1.5% |
| Bits/key | 894.09 | 880.70 | -1.5% |
| Build time | 45.47 s | 39.78 s | -12.5% |

Latency is the headline win; size drop comes from dodging per-bucket cereal framing.

## What changed

- **Shared hash store per filter-group.** `partitionToBuckets` is now called once per filter-group instead of per column, so all M columns in a group share one `(seed, num_buckets)`. `num_buckets` is set to `max(targetBucketCount)` across the group's columns (small detune, measured as +0.4% size in an earlier isolated test but more than compensated by the layout win here).
- **Group-level `BucketArena`.** Each group owns a flat `solution_bits: vector<uint64_t>` with bucket offsets and `(per_col_bits, per_col_seeds)` arrays of length `num_buckets * M`. Within a bucket block, column c's bit range immediately follows column c-1, padded to a 64-bit boundary so existing bit-slicing in `queryCsfCore` works unchanged.
- **Query hot path.** `MultisetCsf::query` hashes the key once per group (1 hash per query when all cols share a group), then loops through the M columns' contiguous bit ranges in one streaming pass.
- **`RaggedMultisetCsf`** ported for parity — each ragged column is its own group (active-key sets differ by length), so it gets the arena benefit but no cross-column hash sharing.
- **Serialization format bumped.** type_ids shifted 101→1101, etc. Old-format files will fail to load; we don't care about backwards compatibility.

## Test plan

- [x] `bin/build.py` (Release and `-t all`)
- [x] All 72 Python tests pass
- [x] All 106 C++ tests pass
- [x] `scripts/benchmark_multiset.py` correctness check (50 random keys verified against ground truth)
- [x] Query latency benchmark on 1M × 100 sample shows -59.7%